### PR TITLE
fix: auditoria do monitor — 16 correções de dados, agregação e robustez

### DIFF
--- a/apps/api/src/services/SummaryService.ts
+++ b/apps/api/src/services/SummaryService.ts
@@ -1,4 +1,10 @@
-import type { EnvironmentValue, ServiceStatusDTO, SummaryDTO } from '@monitor-sefaz/contracts';
+import {
+  averageLatency,
+  isUp,
+  type EnvironmentValue,
+  type ServiceStatusDTO,
+  type SummaryDTO,
+} from '@monitor-sefaz/contracts';
 
 interface Bucket {
   total: number;
@@ -13,14 +19,11 @@ function availability(bucket: Bucket): number {
 export class SummaryService {
   public build(env: EnvironmentValue, services: ServiceStatusDTO[], generatedAt: string): SummaryDTO {
     const total = services.length;
-    const operational = services.filter((s) => s.state === 'OPERATIONAL').length;
+    const operational = services.filter((s) => isUp(s.state)).length;
     const failing = total - operational;
 
-    const latencies = services.filter((s) => s.state === 'OPERATIONAL').map((s) => s.latencyMs);
-    const avgLatencyMs =
-      latencies.length === 0
-        ? null
-        : Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length);
+    const latencies = services.filter((s) => isUp(s.state)).map((s) => s.latencyMs);
+    const avgLatencyMs = averageLatency(latencies);
 
     const byDocument = this.group(services, (s) => s.document);
     const byAuthorizer = this.group(services, (s) => s.authorizer);
@@ -47,7 +50,7 @@ export class SummaryService {
       const key = keyOf(service);
       const bucket = buckets.get(key) ?? { total: 0, operational: 0 };
       bucket.total += 1;
-      if (service.state === 'OPERATIONAL') {
+      if (isUp(service.state)) {
         bucket.operational += 1;
       }
       buckets.set(key, bucket);

--- a/apps/api/src/services/UptimeCalculator.ts
+++ b/apps/api/src/services/UptimeCalculator.ts
@@ -1,4 +1,10 @@
-import type { HistoryPointDTO, IncidentDTO, ServiceStateValue } from '@monitor-sefaz/contracts';
+import {
+  averageLatency,
+  isUp,
+  type HistoryPointDTO,
+  type IncidentDTO,
+  type ServiceStateValue,
+} from '@monitor-sefaz/contracts';
 
 export interface UptimeStats {
   uptime: number;
@@ -16,10 +22,6 @@ const STATE_SEVERITY: Record<ServiceStateValue, number> = {
   DOWN: 4,
 };
 
-/** "No ar" inclui operação normal e contingência (serviço disponível). */
-const isUp = (state: ServiceStateValue): boolean =>
-  state === 'OPERATIONAL' || state === 'CONTINGENCY';
-
 /**
  * Deriva métricas de disponibilidade e incidentes a partir da série temporal
  * de checagens. Lógica pura (sem I/O) — fácil de testar e reutilizar.
@@ -32,10 +34,7 @@ export class UptimeCalculator {
       totalChecks === 0 ? 0 : Number(((operationalChecks / totalChecks) * 100).toFixed(2));
 
     const latencies = points.filter((p) => isUp(p.state)).map((p) => p.latencyMs);
-    const avgLatencyMs =
-      latencies.length === 0
-        ? null
-        : Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length);
+    const avgLatencyMs = averageLatency(latencies);
 
     return { uptime, totalChecks, operationalChecks, avgLatencyMs };
   }

--- a/apps/api/src/sources/AvailabilityStatusSource.ts
+++ b/apps/api/src/sources/AvailabilityStatusSource.ts
@@ -43,6 +43,7 @@ export class AvailabilityStatusSource implements StatusSource {
       cStat: s.cStat,
       xMotivo: null,
       latencyMs: s.latencyMs,
+      source: s.source,
       error: null,
       checkedAt,
     };

--- a/apps/api/src/store/RedisStatusStore.ts
+++ b/apps/api/src/store/RedisStatusStore.ts
@@ -50,6 +50,7 @@ export class RedisStatusStore implements StatusStore {
         state: service.state,
         cStat: service.cStat,
         latencyMs: service.latencyMs,
+        source: service.source,
       };
       const historyKey = this.historyKey(env, service.id);
       pipeline.zadd(historyKey, ts, JSON.stringify(point));

--- a/apps/api/src/store/mappers.ts
+++ b/apps/api/src/store/mappers.ts
@@ -19,6 +19,9 @@ export function toServiceStatusDTO(result: StatusResult): ServiceStatusDTO {
     cStat: result.cStat,
     xMotivo: result.xMotivo,
     latencyMs: result.latencyMs,
+    // O checker SOAP mede latência de rede real (ms contínuos), como a fonte de
+    // disponibilidade — não o "tempo médio" do IntegraNotas.
+    source: 'availability',
     error: result.error,
     checkedAt: result.checkedAt.toISOString(),
   };

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -1,10 +1,12 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { HybridCollector } from '@monitor-sefaz/core';
-import { Environment } from '@monitor-sefaz/catalog';
+import { Catalog, Environment } from '@monitor-sefaz/catalog';
 import {
+  averageLatency,
   fromEnvironment,
   historyFileSchema,
+  isUp,
   type HistoryFileDTO,
   type HistoryPointDTO,
   type ServiceStatusDTO,
@@ -15,20 +17,23 @@ import {
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
 
-/** "No ar" inclui operação normal e contingência (o serviço está disponível). */
-function isUp(s: ServiceStatusDTO): boolean {
-  return s.state === 'OPERATIONAL' || s.state === 'CONTINGENCY';
-}
+/**
+ * Fração mínima do catálogo que uma coleta precisa cobrir para ser publicada.
+ * Abaixo disso, presume-se falha das fontes (não uma queda real da SEFAZ — uma
+ * SEFAZ fora do ar ainda retorna os serviços, com state DOWN/ERROR) e abortamos
+ * sem sobrescrever, preservando o último dado bom. Ajustável por env.
+ */
+const MIN_COVERAGE_RATIO = Number(process.env.MIN_COVERAGE_RATIO ?? 0.75);
 
 function buildSummary(services: ServiceStatusDTO[], generatedAt: string): SummaryDTO {
   const total = services.length;
-  const operational = services.filter(isUp).length;
+  const operational = services.filter((s) => isUp(s.state)).length;
   const group = (keyOf: (s: ServiceStatusDTO) => string): SummaryDTO['byDocument'] => {
     const map = new Map<string, { total: number; operational: number }>();
     for (const s of services) {
       const b = map.get(keyOf(s)) ?? { total: 0, operational: 0 };
       b.total += 1;
-      if (isUp(s)) b.operational += 1;
+      if (isUp(s.state)) b.operational += 1;
       map.set(keyOf(s), b);
     }
     return [...map.entries()]
@@ -40,7 +45,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
       }))
       .sort((a, b) => a.key.localeCompare(b.key));
   };
-  const latencies = services.filter((s) => isUp(s) && s.latencyMs > 0).map((s) => s.latencyMs);
+  const latencies = services.filter((s) => isUp(s.state)).map((s) => s.latencyMs);
   return {
     environment: 'production',
     generatedAt,
@@ -48,9 +53,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
     operational,
     failing: total - operational,
     availability: total === 0 ? 0 : Number(((operational / total) * 100).toFixed(1)),
-    avgLatencyMs: latencies.length
-      ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length)
-      : null,
+    avgLatencyMs: averageLatency(latencies),
     byDocument: group((s) => s.document),
     byAuthorizer: group((s) => s.authorizer),
   };
@@ -82,6 +85,7 @@ function appendHistory(
       state: s.state,
       cStat: s.cStat,
       latencyMs: s.latencyMs,
+      source: s.source,
     };
     const prev = series[s.id] ?? [];
     series[s.id] = [...prev, point].filter((p) => Date.parse(p.timestamp) >= cutoff);
@@ -100,6 +104,20 @@ async function main(): Promise<void> {
   const collector = HybridCollector.createForNode();
   const collected = await collector.collect();
 
+  // Guarda de piso: se a coleta veio muito abaixo do catálogo, ambas as fontes
+  // provavelmente falharam. Abortar com erro (sem escrever) faz o git não ver
+  // diff — o último snapshot bom permanece — e o GitHub Actions falha visível,
+  // em vez de publicar services:[] / availability:0 silenciosamente.
+  const expected = new Catalog().listAll(Environment.Production).length;
+  const floor = Math.floor(expected * MIN_COVERAGE_RATIO);
+  if (collected.length < floor) {
+    console.error(
+      `Coleta abaixo do piso: ${collected.length} de ${expected} serviços ` +
+        `(mínimo ${floor}). Provável falha das fontes; abortando sem sobrescrever.`
+    );
+    process.exit(1);
+  }
+
   const services: ServiceStatusDTO[] = collected.map((s) => ({
     id: `${s.document}:${s.uf}`,
     document: s.document,
@@ -110,6 +128,7 @@ async function main(): Promise<void> {
     cStat: s.cStat,
     xMotivo: null,
     latencyMs: s.latencyMs,
+    source: s.source,
     error: null,
     checkedAt: generatedAt,
   }));

--- a/apps/web/src/api/ApiDataSource.ts
+++ b/apps/web/src/api/ApiDataSource.ts
@@ -1,6 +1,5 @@
 import {
   historyResponseSchema,
-  statusSnapshotSchema,
   summarySchema,
   type HistoryPeriod,
   type HistoryResponseDTO,
@@ -9,6 +8,7 @@ import {
 } from '@monitor-sefaz/contracts';
 import {
   fetchJson,
+  parseStatusSnapshot,
   type DataSource,
   type HistorySeries,
   type StatusFilters,
@@ -25,8 +25,9 @@ export class ApiDataSource implements DataSource {
     const params = new URLSearchParams({ env: 'production' });
     if (filters.document) params.set('document', filters.document);
     if (filters.uf) params.set('uf', filters.uf);
-    return statusSnapshotSchema.parse(
-      await fetchJson(`${this.baseUrl}/api/v1/status?${params.toString()}`)
+    return parseStatusSnapshot(
+      await fetchJson(`${this.baseUrl}/api/v1/status?${params.toString()}`),
+      'API'
     );
   }
 

--- a/apps/web/src/api/DataSource.ts
+++ b/apps/web/src/api/DataSource.ts
@@ -1,9 +1,10 @@
-import type {
-  HistoryPeriod,
-  HistoryPointDTO,
-  HistoryResponseDTO,
-  StatusSnapshotDTO,
-  SummaryDTO,
+import {
+  resilientStatusSnapshotSchema,
+  type HistoryPeriod,
+  type HistoryPointDTO,
+  type HistoryResponseDTO,
+  type StatusSnapshotDTO,
+  type SummaryDTO,
 } from '@monitor-sefaz/contracts';
 
 /** Mapa `id do serviço` → série de pontos, usado para os sparklines dos cards. */
@@ -35,4 +36,20 @@ export async function fetchJson(url: string): Promise<unknown> {
     throw new Error(`Falha ao buscar ${url}: HTTP ${response.status}`);
   }
   return response.json();
+}
+
+/**
+ * Valida um snapshot de status de forma resiliente em duas camadas:
+ * 1. services inválidos individualmente são descartados (schema tolerante);
+ * 2. se a estrutura toda for inválida (ex.: `services` não é array), em vez de
+ *    lançar e apagar o dashboard, loga e devolve um snapshot vazio — a UI mostra
+ *    o estado "sem serviços" em vez de uma tela de erro.
+ */
+export function parseStatusSnapshot(data: unknown, source: string): StatusSnapshotDTO {
+  const result = resilientStatusSnapshotSchema.safeParse(data);
+  if (result.success) {
+    return result.data;
+  }
+  console.warn(`Snapshot de status inválido (${source}); exibindo vazio.`, result.error.issues);
+  return { environment: 'production', generatedAt: new Date().toISOString(), services: [] };
 }

--- a/apps/web/src/api/HybridDataSource.ts
+++ b/apps/web/src/api/HybridDataSource.ts
@@ -19,12 +19,25 @@ export class HybridDataSource implements DataSource {
     private readonly history: DataSource
   ) {}
 
-  public getStatus(filters?: StatusFilters): Promise<StatusSnapshotDTO> {
-    return this.live.getStatus(filters);
+  public async getStatus(filters?: StatusFilters): Promise<StatusSnapshotDTO> {
+    try {
+      return await this.live.getStatus(filters);
+    } catch (err) {
+      // A fonte ao vivo (Worker/API) caiu: em vez de derrubar o dashboard,
+      // servimos o último snapshot estático versionado. Um monitor de
+      // disponibilidade não pode sair do ar junto com sua própria fonte.
+      console.warn('Fonte ao vivo indisponível em getStatus; usando o estático.', err);
+      return this.history.getStatus(filters);
+    }
   }
 
-  public getSummary(): Promise<SummaryDTO> {
-    return this.live.getSummary();
+  public async getSummary(): Promise<SummaryDTO> {
+    try {
+      return await this.live.getSummary();
+    } catch (err) {
+      console.warn('Fonte ao vivo indisponível em getSummary; usando o estático.', err);
+      return this.history.getSummary();
+    }
   }
 
   public getHistory(id: string, period: HistoryPeriod): Promise<HistoryResponseDTO> {

--- a/apps/web/src/api/StaticDataSource.ts
+++ b/apps/web/src/api/StaticDataSource.ts
@@ -1,6 +1,5 @@
 import {
   historyFileSchema,
-  statusSnapshotSchema,
   summarySchema,
   type HistoryPeriod,
   type HistoryResponseDTO,
@@ -9,6 +8,7 @@ import {
 } from '@monitor-sefaz/contracts';
 import {
   fetchJson,
+  parseStatusSnapshot,
   type DataSource,
   type HistorySeries,
   type StatusFilters,
@@ -30,7 +30,10 @@ export class StaticDataSource implements DataSource {
   constructor(private readonly base: string) {}
 
   public async getStatus(filters: StatusFilters = {}): Promise<StatusSnapshotDTO> {
-    const snapshot = statusSnapshotSchema.parse(await fetchJson(`${this.base}data/status.json`));
+    const snapshot = parseStatusSnapshot(
+      await fetchJson(`${this.base}data/status.json`),
+      'estático'
+    );
     if (!filters.document && !filters.uf) {
       return snapshot;
     }

--- a/apps/web/src/components/LatencyChart.tsx
+++ b/apps/web/src/components/LatencyChart.tsx
@@ -15,11 +15,21 @@ interface LatencyChartProps {
 /** Gráfico de área (Recharts) da latência ao longo do tempo. */
 export function LatencyChart({ points }: LatencyChartProps) {
   const data = points
-    .filter((p) => p.latencyMs > 0)
+    // tMed do IntegraNotas vem em segundos inteiros: 0 é um valor legítimo
+    // (resposta rápida), não "sem dado". Incluímos os zeros para não esvaziar
+    // o gráfico nas UFs que reportam tMed=0.
+    .filter((p) => p.latencyMs >= 0)
     .map((p) => ({
       t: new Date(p.timestamp).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }),
       ms: p.latencyMs,
     }));
+
+  // O significado de latencyMs depende da fonte: 'availability' é latência de
+  // rede real; o resto (integranotas / ausente) é o "tempo médio" da SEFAZ.
+  // Rotulamos pela fonte predominante para não anunciar a métrica errada.
+  const netCount = points.filter((p) => p.source === 'availability').length;
+  const isNetwork = netCount > points.length / 2;
+  const label = isNetwork ? 'Latência de rede' : 'Tempo médio (SEFAZ)';
 
   if (data.length < 2) {
     return (
@@ -61,7 +71,7 @@ export function LatencyChart({ points }: LatencyChartProps) {
               fontSize: 12,
             }}
             labelStyle={{ color: 'var(--text-dim)' }}
-            formatter={(v: number) => [`${v} ms`, 'Latência']}
+            formatter={(v: number) => [`${v} ms`, label]}
           />
           <Area
             type="monotone"

--- a/apps/web/src/components/ServiceCard.tsx
+++ b/apps/web/src/components/ServiceCard.tsx
@@ -20,7 +20,8 @@ export function ServiceCard({ service, spark = [], onSelect }: ServiceCardProps)
   const Icon = meta.icon;
   const ufName = UF_NAME[service.uf] ?? service.uf;
   const sparkData = spark
-    .filter((p) => p.latencyMs > 0)
+    // tMed=0 é valor legítimo (ver LatencyChart): incluímos os zeros.
+    .filter((p) => p.latencyMs >= 0)
     .map((p, i) => ({ i, v: p.latencyMs }));
   // Latência exibida = último ponto da MESMA série do gráfico (history.json),
   // para o card e o gráfico de detalhe não divergirem. Sem série, cai para o

--- a/apps/web/src/components/ServiceDetailPanel.tsx
+++ b/apps/web/src/components/ServiceDetailPanel.tsx
@@ -6,14 +6,17 @@ import { StatusBadge } from './StatusBadge.js';
 import { UptimeBar } from './UptimeBar.js';
 import { LatencyChart } from './LatencyChart.js';
 import { DOC_LABEL, DOC_DESCRIPTION, UF_NAME } from '../lib/labels.js';
-import { computeUptime } from '../lib/uptime.js';
+import { computeUptime, maxGapMs } from '../lib/uptime.js';
 
 interface ServiceDetailPanelProps {
   service: ServiceStatusDTO;
   onClose: () => void;
 }
 
-const PERIODS: HistoryPeriod[] = ['1h', '6h', '24h', '72h'];
+// '1h' e '6h' foram omitidos: com a cadência real de coleta (~3h/ponto), essas
+// janelas rendem 0–2 amostras — o gráfico fica vazio e o uptime sai sobre uma
+// amostra única. Mantemos só janelas com densidade de pontos significativa.
+const PERIODS: HistoryPeriod[] = ['24h', '72h'];
 const SVRS_DERIVED = new Set<string>([DocumentType.MDFe, DocumentType.DCe]);
 
 /** Drawer com histórico de uptime e latência de um serviço. */
@@ -22,6 +25,7 @@ export function ServiceDetailPanel({ service, onClose }: ServiceDetailPanelProps
   const history = useServiceHistory(service.id, period);
   const points = history.data?.points ?? [];
   const stats = computeUptime(points, period);
+  const maxGapHours = Math.round(maxGapMs(points) / (60 * 60 * 1000));
   const isDerived = SVRS_DERIVED.has(service.document);
 
   return (
@@ -111,7 +115,7 @@ export function ServiceDetailPanel({ service, onClose }: ServiceDetailPanelProps
             {stats.lowCoverage && (
               <p className="mt-1 flex gap-1.5 text-xs" style={{ color: 'var(--slow)' }}>
                 <Info className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                Cobertura de {stats.coverage}% no período — instabilidades em janelas sem leitura
+                Houve um intervalo de ~{maxGapHours}h sem leitura — instabilidades nessa janela
                 podem não ter sido registradas.
               </p>
             )}

--- a/apps/web/src/components/ServiceGrid.tsx
+++ b/apps/web/src/components/ServiceGrid.tsx
@@ -16,10 +16,13 @@ export function ServiceGrid({ services, series, onSelect, pageSize = 24 }: Servi
   const [page, setPage] = useState(0);
   const pages = Math.max(1, Math.ceil(services.length / pageSize));
 
-  // Volta para a primeira página quando o filtro muda o total.
+  // Volta para a primeira página quando o CONJUNTO filtrado muda. Usar o total
+  // (services.length) não bastava: trocar de um filtro para outro de mesmo
+  // tamanho mantinha a página atual, exibindo um recorte arbitrário.
+  const filterKey = services.map((s) => s.id).join(',');
   useEffect(() => {
     setPage(0);
-  }, [services.length]);
+  }, [filterKey]);
 
   const current = Math.min(page, pages - 1);
   const slice = services.slice(current * pageSize, current * pageSize + pageSize);

--- a/apps/web/src/components/UptimeBar.tsx
+++ b/apps/web/src/components/UptimeBar.tsx
@@ -26,7 +26,7 @@ export function UptimeBar({ points }: UptimeBarProps) {
           style={{ background: STATE_META[point.state].color }}
           title={`${new Date(point.timestamp).toLocaleString('pt-BR')} — ${
             STATE_META[point.state].label
-          }${point.latencyMs > 0 ? ` (${point.latencyMs}ms)` : ''}`}
+          }${point.latencyMs >= 0 ? ` (${point.latencyMs}ms)` : ''}`}
         />
       ))}
     </div>

--- a/apps/web/src/lib/uptime.ts
+++ b/apps/web/src/lib/uptime.ts
@@ -1,4 +1,4 @@
-import type { HistoryPeriod, HistoryPointDTO } from '@monitor-sefaz/contracts';
+import { isUp, type HistoryPeriod, type HistoryPointDTO } from '@monitor-sefaz/contracts';
 
 const PERIOD_MS: Record<HistoryPeriod, number> = {
   '1h': 60 * 60 * 1000,
@@ -7,45 +7,71 @@ const PERIOD_MS: Record<HistoryPeriod, number> = {
   '72h': 72 * 60 * 60 * 1000,
 };
 
-/** Intervalo nominal entre coletas (cron horário). Usado para estimar cobertura. */
-const EXPECTED_INTERVAL_MS = 60 * 60 * 1000;
+/**
+ * Cadência fallback (ms) quando há poucos pontos para inferir o intervalo real.
+ * O cron do Actions é declarado horário mas é best-effort: na prática roda a
+ * cada ~3h. Só serve de chute inicial — com ≥2 pontos usamos a mediana real.
+ */
+const FALLBACK_INTERVAL_MS = 3 * 60 * 60 * 1000;
 
 export interface UptimeStats {
   /** % de disponibilidade no período (0–100), ou null se não há pontos. */
   uptime: number | null;
   /** Pontos efetivamente coletados no período. */
   points: number;
-  /** Pontos esperados se a amostragem fosse regular (cron horário). */
+  /** Pontos esperados na cadência REAL observada (mediana dos gaps). */
   expectedPoints: number;
   /** % de cobertura do período (points / expectedPoints, teto 100). */
   coverage: number;
-  /** True quando a cobertura é baixa o bastante para o uptime ser pouco confiável. */
+  /** True quando há um buraco anormal — instabilidade pode ter passado batida. */
   lowCoverage: boolean;
+}
+
+/** Mediana dos intervalos (ms) entre pontos consecutivos; 0 se < 2 pontos. */
+function medianGapMs(points: HistoryPointDTO[]): number {
+  if (points.length < 2) return 0;
+  const ts = points.map((p) => Date.parse(p.timestamp)).sort((a, b) => a - b);
+  const gaps: number[] = [];
+  for (let i = 1; i < ts.length; i += 1) gaps.push(ts[i]! - ts[i - 1]!);
+  gaps.sort((a, b) => a - b);
+  const mid = Math.floor(gaps.length / 2);
+  return gaps.length % 2 === 0 ? (gaps[mid - 1]! + gaps[mid]!) / 2 : gaps[mid]!;
 }
 
 /**
  * Calcula uptime e a CONFIABILIDADE dele. O uptime simples (operacionais /
  * total de pontos) engana com histórico esparso: uma falha de horas que caia
- * entre coletas não aparece. Por isso reportamos também a cobertura — quanto do
- * período foi de fato amostrado — para a UI avisar quando o número é frágil.
+ * entre coletas não aparece. Em vez de comparar contra um intervalo fixo
+ * presumido (o cron é best-effort e roda bem menos que de hora em hora), medimos
+ * a CADÊNCIA REAL pela mediana dos gaps observados e só alertamos quando há um
+ * buraco anormalmente grande — aí sim uma instabilidade pode ter passado batida.
  */
 export function computeUptime(points: HistoryPointDTO[], period: HistoryPeriod): UptimeStats {
   const total = points.length;
   if (total === 0) {
     return { uptime: null, points: 0, expectedPoints: 0, coverage: 0, lowCoverage: true };
   }
-  const operational = points.filter((p) => p.state === 'OPERATIONAL').length;
+  const operational = points.filter((p) => isUp(p.state)).length;
   const uptime = Number(((operational / total) * 100).toFixed(1));
 
-  const expectedPoints = Math.max(1, Math.round(PERIOD_MS[period] / EXPECTED_INTERVAL_MS));
+  // Cadência típica observada (mediana). Com 1 ponto, cai no fallback.
+  const typicalGap = medianGapMs(points);
+  const interval = typicalGap > 0 ? typicalGap : FALLBACK_INTERVAL_MS;
+  const expectedPoints = Math.max(1, Math.round(PERIOD_MS[period] / interval));
   const coverage = Math.min(100, Math.round((total / expectedPoints) * 100));
+
+  // Pouco confiável quando há um buraco anormal (maior gap > 2,5× a cadência
+  // típica) OU quando amostramos menos da metade do período. A 2ª condição
+  // cobre o caso degenerado de 0/1 ponto, em que maxGapMs é 0 e não acusaria
+  // a janela inteira sem leitura.
+  const lowCoverage = coverage < 50 || maxGapMs(points) > interval * 2.5;
 
   return {
     uptime,
     points: total,
     expectedPoints,
     coverage,
-    lowCoverage: coverage < 60,
+    lowCoverage,
   };
 }
 

--- a/apps/web/test/uptime.test.ts
+++ b/apps/web/test/uptime.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import type { HistoryPointDTO } from '@monitor-sefaz/contracts';
+import { computeUptime } from '../src/lib/uptime.js';
+
+function pt(timestamp: string, state: HistoryPointDTO['state'], latencyMs = 0): HistoryPointDTO {
+  return { timestamp, state, cStat: state === 'OPERATIONAL' ? 107 : null, latencyMs };
+}
+
+describe('computeUptime', () => {
+  it('conta CONTINGENCY como no ar (alinhado à API e ao badge "no ar")', () => {
+    const points = [
+      pt('2026-06-28T00:00:00Z', 'OPERATIONAL'),
+      pt('2026-06-28T03:00:00Z', 'CONTINGENCY'),
+      pt('2026-06-28T06:00:00Z', 'OPERATIONAL'),
+    ];
+    // todos no ar → 100%, não 66.7% (o bug contava só OPERATIONAL)
+    expect(computeUptime(points, '24h').uptime).toBe(100);
+  });
+
+  it('conta DOWN/ERROR como queda', () => {
+    const points = [
+      pt('2026-06-28T00:00:00Z', 'OPERATIONAL'),
+      pt('2026-06-28T03:00:00Z', 'DOWN'),
+    ];
+    expect(computeUptime(points, '24h').uptime).toBe(50);
+  });
+
+  it('retorna uptime null quando não há pontos', () => {
+    expect(computeUptime([], '24h').uptime).toBeNull();
+  });
+
+  it('não reporta cobertura cheia com um único ponto numa janela longa', () => {
+    const stats = computeUptime([pt('2026-06-28T00:00:00Z', 'OPERATIONAL')], '72h');
+    // com 1 ponto não dá para afirmar cobertura — deve sinalizar baixa cobertura
+    expect(stats.lowCoverage).toBe(true);
+  });
+});

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -6,7 +6,9 @@ import {
   type IntegraNotasFetcher,
 } from '@monitor-sefaz/core';
 import {
+  averageLatency,
   fromEnvironment,
+  isUp,
   type ServiceStatusDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
@@ -58,24 +60,21 @@ function toDTO(s: CollectedStatus, checkedAt: string): ServiceStatusDTO {
     cStat: s.cStat,
     xMotivo: null,
     latencyMs: s.latencyMs,
+    source: s.source,
     error: null,
     checkedAt,
   };
 }
 
-/** "No ar" inclui operação normal e contingência. */
-const isUp = (s: ServiceStatusDTO): boolean =>
-  s.state === 'OPERATIONAL' || s.state === 'CONTINGENCY';
-
 function buildSummary(services: ServiceStatusDTO[], generatedAt: string): SummaryDTO {
   const total = services.length;
-  const operational = services.filter(isUp).length;
+  const operational = services.filter((s) => isUp(s.state)).length;
   const group = (keyOf: (s: ServiceStatusDTO) => string): SummaryDTO['byDocument'] => {
     const map = new Map<string, { total: number; operational: number }>();
     for (const s of services) {
       const b = map.get(keyOf(s)) ?? { total: 0, operational: 0 };
       b.total += 1;
-      if (isUp(s)) b.operational += 1;
+      if (isUp(s.state)) b.operational += 1;
       map.set(keyOf(s), b);
     }
     return [...map.entries()]
@@ -87,7 +86,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
       }))
       .sort((a, b) => a.key.localeCompare(b.key));
   };
-  const latencies = services.filter((s) => isUp(s) && s.latencyMs > 0).map((s) => s.latencyMs);
+  const latencies = services.filter((s) => isUp(s.state)).map((s) => s.latencyMs);
   return {
     environment: 'production',
     generatedAt,
@@ -95,9 +94,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
     operational,
     failing: total - operational,
     availability: total === 0 ? 0 : Number(((operational / total) * 100).toFixed(1)),
-    avgLatencyMs: latencies.length
-      ? Math.round(latencies.reduce((a, b) => a + b, 0) / latencies.length)
-      : null,
+    avgLatencyMs: averageLatency(latencies),
     byDocument: group((s) => s.document),
     byAuthorizer: group((s) => s.authorizer),
   };

--- a/packages/contracts/src/availability.ts
+++ b/packages/contracts/src/availability.ts
@@ -1,0 +1,32 @@
+import type { ServiceStateValue } from './schemas.js';
+
+/**
+ * Fonte ÚNICA da definição de "no ar". Um serviço está disponível quando opera
+ * normalmente OU via contingência (SVC) — em ambos a SEFAZ responde (cStat 107).
+ *
+ * Aceita string genérica porque o enum `ServiceState` do core tem os MESMOS
+ * valores textuais (`Operational = 'OPERATIONAL'`, etc.), então collector,
+ * worker, API, core e front compartilham este predicado sem conversão.
+ *
+ * Antes existiam 4 cópias literais e 3 divergências (algumas contavam só
+ * OPERATIONAL), fazendo a MESMA frota render availability/uptime diferentes
+ * conforme o app. Manter um só lugar elimina essa divergência.
+ */
+export function isUp(state: ServiceStateValue | string): boolean {
+  return state === 'OPERATIONAL' || state === 'CONTINGENCY';
+}
+
+/**
+ * Latência média (ms) das medições, arredondada; `null` se não houver nenhuma.
+ *
+ * IMPORTANTE: NÃO descarta `latencyMs === 0`. O valor vem do "tempo médio" da
+ * SEFAZ em segundos inteiros (via IntegraNotas) e 0 é uma medição LEGÍTIMA
+ * (resposta sub-segundo), não "sem dado". Filtrar `> 0` — como o código fazia —
+ * inflava a média (publicava ~1000ms quando o real era ~326ms). Só valores
+ * negativos (sentinela de ausência, hoje inexistente) são ignorados.
+ */
+export function averageLatency(latenciesMs: readonly number[]): number | null {
+  const valid = latenciesMs.filter((ms) => ms >= 0);
+  if (valid.length === 0) return null;
+  return Math.round(valid.reduce((a, b) => a + b, 0) / valid.length);
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,1 +1,2 @@
 export * from './schemas.js';
+export * from './availability.js';

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -17,6 +17,15 @@ export const serviceStateSchema = z.enum([
 ]);
 export type ServiceStateValue = z.infer<typeof serviceStateSchema>;
 
+/**
+ * Origem da medição — define a semântica de `latencyMs`:
+ * `integranotas` = tempo médio da SEFAZ (s×1000); `availability` = latência de
+ * rede do fetch. Opcional para compatibilidade com dados gravados antes deste
+ * campo; ausente é tratado como `integranotas` (a fonte primária e dominante).
+ */
+export const statusSourceSchema = z.enum(['integranotas', 'availability']);
+export type StatusSourceValue = z.infer<typeof statusSourceSchema>;
+
 /** Ambiente em formato textual usado na API (contrato em inglês). */
 export const environmentSchema = z.enum(['production', 'homologation']);
 export type EnvironmentValue = z.infer<typeof environmentSchema>;
@@ -43,6 +52,7 @@ export const serviceStatusSchema = z.object({
   cStat: z.number().nullable(),
   xMotivo: z.string().nullable(),
   latencyMs: z.number(),
+  source: statusSourceSchema.optional(),
   error: z.string().nullable(),
   checkedAt: z.string(), // ISO 8601
 });
@@ -55,6 +65,20 @@ export const statusSnapshotSchema = z.object({
   services: z.array(serviceStatusSchema),
 });
 export type StatusSnapshotDTO = z.infer<typeof statusSnapshotSchema>;
+
+/**
+ * Variante TOLERANTE do snapshot para o front consumir fontes que podem evoluir
+ * (estado novo, cStat inesperado): um service inválido é DESCARTADO em vez de
+ * derrubar todo o snapshot. A API/worker continuam emitindo `statusSnapshotSchema`
+ * estrito — esta só relaxa a leitura, degradando em vez de esconder tudo.
+ */
+export const resilientStatusSnapshotSchema = z.object({
+  environment: environmentSchema,
+  generatedAt: z.string(),
+  services: z
+    .array(serviceStatusSchema.nullable().catch(null))
+    .transform((items) => items.filter((s): s is ServiceStatusDTO => s !== null)),
+});
 
 /** Resumo agregado de disponibilidade. */
 export const summaryGroupSchema = z.object({
@@ -87,6 +111,7 @@ export const historyPointSchema = z.object({
   state: serviceStateSchema,
   cStat: z.number().nullable(),
   latencyMs: z.number(),
+  source: statusSourceSchema.optional(),
 });
 export type HistoryPointDTO = z.infer<typeof historyPointSchema>;
 

--- a/packages/contracts/test/availability.test.ts
+++ b/packages/contracts/test/availability.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { isUp, averageLatency } from '../src/availability.js';
+
+describe('isUp', () => {
+  it('conta OPERATIONAL e CONTINGENCY como no ar', () => {
+    expect(isUp('OPERATIONAL')).toBe(true);
+    expect(isUp('CONTINGENCY')).toBe(true);
+  });
+
+  it('conta SLOWDOWN, DOWN e ERROR como fora do ar', () => {
+    expect(isUp('SLOWDOWN')).toBe(false);
+    expect(isUp('DOWN')).toBe(false);
+    expect(isUp('ERROR')).toBe(false);
+  });
+});
+
+describe('averageLatency', () => {
+  it('inclui medições de 0ms (tMed=0 é resposta rápida legítima, não "sem dado")', () => {
+    // 91 zeros + 44 de 1000ms ≈ a distribuição real observada → ~326, não 1000.
+    const lat = [...Array(91).fill(0), ...Array(44).fill(1000)];
+    expect(averageLatency(lat)).toBe(326);
+  });
+
+  it('não infla a média descartando os zeros', () => {
+    expect(averageLatency([0, 0, 1000])).toBe(333);
+  });
+
+  it('retorna null quando não há nenhuma medição', () => {
+    expect(averageLatency([])).toBeNull();
+  });
+
+  it('ignora apenas valores negativos (sentinela de ausência)', () => {
+    expect(averageLatency([-1, 1000, 1000])).toBe(1000);
+  });
+
+  it('arredonda para inteiro', () => {
+    expect(averageLatency([100, 101])).toBe(101);
+  });
+});

--- a/packages/contracts/test/schemas.test.ts
+++ b/packages/contracts/test/schemas.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import { resilientStatusSnapshotSchema, statusSnapshotSchema } from '../src/schemas.js';
+
+function service(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    id: 'NFe:SP',
+    document: 'NFe',
+    uf: 'SP',
+    authorizer: 'SVRS',
+    environment: 'production',
+    state: 'OPERATIONAL',
+    cStat: 107,
+    xMotivo: null,
+    latencyMs: 0,
+    error: null,
+    checkedAt: '2026-06-29T12:00:00Z',
+    ...over,
+  };
+}
+
+describe('resilientStatusSnapshotSchema', () => {
+  it('descarta o service inválido e mantém os válidos', () => {
+    const snapshot = {
+      environment: 'production',
+      generatedAt: '2026-06-29T12:00:00Z',
+      services: [
+        service({ id: 'NFe:SP' }),
+        service({ id: 'NFe:RJ', state: 'MAINTENANCE' }), // estado desconhecido
+        service({ id: 'NFe:MG' }),
+      ],
+    };
+    // o schema estrito derrubaria o snapshot inteiro
+    expect(() => statusSnapshotSchema.parse(snapshot)).toThrow();
+    // o resiliente mantém os 2 válidos
+    const parsed = resilientStatusSnapshotSchema.parse(snapshot);
+    expect(parsed.services.map((s) => s.id)).toEqual(['NFe:SP', 'NFe:MG']);
+  });
+
+  it('mantém todos quando todos são válidos', () => {
+    const snapshot = {
+      environment: 'production',
+      generatedAt: '2026-06-29T12:00:00Z',
+      services: [service({ id: 'NFe:SP' }), service({ id: 'NFe:RJ' })],
+    };
+    expect(resilientStatusSnapshotSchema.parse(snapshot).services).toHaveLength(2);
+  });
+
+  it('falha quando a estrutura externa é inválida (services não é array)', () => {
+    const bad = { environment: 'production', generatedAt: 'x', services: 'nope' };
+    expect(resilientStatusSnapshotSchema.safeParse(bad).success).toBe(false);
+  });
+});

--- a/packages/contracts/vitest.config.ts
+++ b/packages/contracts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/core/src/availability/AvailabilityCollector.ts
+++ b/packages/core/src/availability/AvailabilityCollector.ts
@@ -29,6 +29,14 @@ function stateToCStat(state: ServiceState): number | null {
   }
 }
 
+/**
+ * De onde veio a medição — define a SEMÂNTICA de `latencyMs`:
+ * - `integranotas`: tempo médio da SEFAZ (segundos×1000, tipicamente 0/1000/6000);
+ * - `availability`: latência de rede real do fetch da página oficial (ms contínuos).
+ * Sem isso, o gráfico colaria as duas grandezas na mesma série.
+ */
+export type StatusSource = 'integranotas' | 'availability';
+
 /** Status coletado de um serviço (documento + UF), pronto para virar DTO. */
 export interface CollectedStatus {
   readonly document: DocumentType;
@@ -36,8 +44,9 @@ export interface CollectedStatus {
   readonly authorizer: AuthorizerCode;
   readonly state: ServiceState;
   readonly cStat: number | null;
-  /** Tempo de resposta (ms) da SEFAZ ao buscar a página de disponibilidade. */
+  /** Latência (ms); a semântica depende de `source` — ver {@link StatusSource}. */
   readonly latencyMs: number;
+  readonly source: StatusSource;
 }
 
 /**
@@ -129,6 +138,7 @@ export class AvailabilityCollector {
         state: row.state,
         cStat: stateToCStat(row.state),
         latencyMs: latencyByAuthorizer.get(entry.authorizer) ?? 0,
+        source: 'availability',
       });
     }
     return out;

--- a/packages/core/src/availability/AvailabilityProvider.ts
+++ b/packages/core/src/availability/AvailabilityProvider.ts
@@ -32,10 +32,17 @@ const BROWSER_UA =
  * loop de redirect sem cookies; por isso usamos um cookie jar e um User-Agent
  * de browser. Esta é a mesma estratégia de monitores públicos da SEFAZ.
  */
+/** Espera `ms` antes de resolver. Injetável para os testes não dormirem de verdade. */
+export type Sleeper = (ms: number) => Promise<void>;
+const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
 export class HttpAvailabilityProvider {
   private readonly http: AxiosInstance;
 
-  constructor(private readonly timeoutMs = 20_000) {
+  constructor(
+    private readonly timeoutMs = 20_000,
+    private readonly sleep: Sleeper = defaultSleeper
+  ) {
     const jar = new CookieJar();
     this.http = wrapper(
       axios.create({
@@ -77,8 +84,11 @@ export class HttpAvailabilityProvider {
     // Cada documento tem layout de colunas próprio (NF-e usa índice 5, CT-e usa 2).
     const parser = new AvailabilityParser(document);
     let lastError: unknown;
+    const totalAttempts = urls.length * attemptsPerUrl;
+    let attemptIndex = 0;
     for (const url of urls) {
       for (let attempt = 1; attempt <= attemptsPerUrl; attempt += 1) {
+        attemptIndex += 1;
         try {
           const response = await this.http.get<ArrayBuffer>(url);
           const html = Buffer.from(response.data).toString('latin1');
@@ -89,6 +99,13 @@ export class HttpAvailabilityProvider {
           lastError = new Error(`resposta sem linhas de status (HTTP ${response.status})`);
         } catch (err) {
           lastError = err;
+        }
+        // Backoff antes da PRÓXIMA tentativa (nunca após a última): dá tempo de
+        // uma falha transitória passar e não martela a SEFAZ em milissegundos,
+        // o que agravaria o rate-limit. Linear (500ms × n) com jitter ±20%.
+        if (attemptIndex < totalAttempts) {
+          const base = 500 * attempt;
+          await this.sleep(Math.round(base * (0.8 + Math.random() * 0.4)));
         }
       }
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -61,6 +61,7 @@ export {
 export {
   AvailabilityCollector,
   type CollectedStatus,
+  type StatusSource,
   type AvailabilityProviderLike,
 } from './availability/AvailabilityCollector.js';
 

--- a/packages/core/src/integranotas/HybridCollector.ts
+++ b/packages/core/src/integranotas/HybridCollector.ts
@@ -36,14 +36,34 @@ export class HybridCollector implements StatusCollectorLike {
   }
 
   public async collect(): Promise<CollectedStatus[]> {
+    let primary: CollectedStatus[] = [];
     try {
-      const primary = await this.primary.collect();
-      if (primary.length >= this.minServices) {
-        return primary;
-      }
+      primary = await this.primary.collect();
     } catch {
-      // cai para o fallback
+      // primário indisponível — primary fica []
     }
-    return this.fallback.collect();
+
+    // Primário completo: usa direto (caminho normal).
+    if (primary.length >= this.minServices) {
+      return primary;
+    }
+
+    // Primário parcial ou vazio: em vez de DESCARTAR os dados reais por-UF que o
+    // primário trouxe, buscamos o fallback e usamos ele só para COMPLETAR as
+    // lacunas (o primário tem precedência por ser medição por estado, não
+    // derivada do autorizador). Se o fallback falhar, ficamos com o primário.
+    let fallback: CollectedStatus[] = [];
+    try {
+      fallback = await this.fallback.collect();
+    } catch {
+      return primary;
+    }
+
+    const key = (s: CollectedStatus): string => `${s.document}:${s.uf}`;
+    const merged = new Map(fallback.map((s) => [key(s), s]));
+    for (const s of primary) {
+      merged.set(key(s), s); // primário sobrescreve o fallback
+    }
+    return [...merged.values()];
   }
 }

--- a/packages/core/src/integranotas/IntegraNotasCollector.ts
+++ b/packages/core/src/integranotas/IntegraNotasCollector.ts
@@ -61,6 +61,7 @@ export class IntegraNotasCollector {
           cStat: stateToCStat(row.state),
           // tMed é em segundos; convertemos para ms (0 quando ausente).
           latencyMs: row.tMedSeconds != null ? row.tMedSeconds * 1000 : 0,
+          source: 'integranotas',
         });
       }
     }

--- a/packages/core/src/integranotas/IntegraNotasProvider.ts
+++ b/packages/core/src/integranotas/IntegraNotasProvider.ts
@@ -92,8 +92,18 @@ export class IntegraNotasProvider {
     const body = await this.fetcher(`${BASE}/${slug}`);
     const parsed = JSON.parse(body) as IntegraNotasPayload;
     const d = parsed.dados;
-    if (!d?.labels || !d.backgroundColor) {
-      throw new Error('IntegraNotas: payload sem dados.labels');
+    // Exigimos labels, backgroundColor E data com o MESMO comprimento de labels.
+    // Sem essa checagem, um payload sem `data` faria tMed=-1 para todas as UFs e
+    // todas virariam Error silenciosamente — sem lançar, o híbrido seguiria com
+    // 27 "serviços fora do ar" e o fallback nunca dispararia. Lançar aqui faz o
+    // HybridCollector pular este documento e, se necessário, cair no fallback.
+    if (
+      !d?.labels ||
+      !d.backgroundColor ||
+      !Array.isArray(d.data) ||
+      d.data.length !== d.labels.length
+    ) {
+      throw new Error('IntegraNotas: payload incompleto (labels/data/backgroundColor)');
     }
 
     const rows: IntegraNotasRow[] = [];

--- a/packages/core/src/report/StatusReport.ts
+++ b/packages/core/src/report/StatusReport.ts
@@ -1,13 +1,22 @@
 import { ServiceState, type StatusResult } from '../domain/types.js';
 
+/**
+ * "No ar" inclui operação normal e contingência (a SEFAZ responde em ambos).
+ * Espelha o `isUp` de @monitor-sefaz/contracts — duplicado aqui de propósito
+ * para não acoplar o core ao pacote de contratos. Mantenha os dois em sincronia.
+ */
+function isUp(state: ServiceState): boolean {
+  return state === ServiceState.Operational || state === ServiceState.Contingency;
+}
+
 /** Resumo agregado de uma rodada de consultas. */
 export interface StatusSummary {
   readonly total: number;
   readonly operational: number;
   readonly failing: number;
-  /** Percentual de serviços operacionais (0–100, uma casa decimal). */
+  /** Percentual de serviços no ar (operacional ou contingência) — 0–100, 1 casa. */
   readonly availability: number;
-  /** Latência média (ms) considerando apenas serviços operacionais. */
+  /** Latência média (ms) considerando serviços no ar; inclui medições de 0ms. */
   readonly avgLatencyMs: number | null;
 }
 
@@ -15,13 +24,11 @@ export interface StatusSummary {
 export class StatusReport {
   public summarize(results: readonly StatusResult[]): StatusSummary {
     const total = results.length;
-    const operational = results.filter((r) => r.state === ServiceState.Operational).length;
+    const operational = results.filter((r) => isUp(r.state)).length;
     const failing = total - operational;
     const availability = total === 0 ? 0 : Number(((operational / total) * 100).toFixed(1));
 
-    const latencies = results
-      .filter((r) => r.state === ServiceState.Operational && r.latencyMs > 0)
-      .map((r) => r.latencyMs);
+    const latencies = results.filter((r) => isUp(r.state)).map((r) => r.latencyMs);
     const avgLatencyMs =
       latencies.length === 0
         ? null

--- a/packages/core/test/integranotas/HybridCollector.test.ts
+++ b/packages/core/test/integranotas/HybridCollector.test.ts
@@ -1,34 +1,50 @@
 import { describe, it, expect, vi } from 'vitest';
-import { DocumentType } from '@monitor-sefaz/catalog';
+import { DocumentType, type UF } from '@monitor-sefaz/catalog';
 import { HybridCollector, type StatusCollectorLike } from '../../src/integranotas/HybridCollector.js';
-import { ServiceState, type CollectedStatus } from '../../src/index.js';
+import { ServiceState, type CollectedStatus, type StatusSource } from '../../src/index.js';
 
-function fakeStatus(n: number): CollectedStatus[] {
+// 27 UFs reais → chaves document:uf distintas, para o merge não colapsar.
+const UFS: UF[] = [
+  'AC', 'AL', 'AP', 'AM', 'BA', 'CE', 'DF', 'ES', 'GO', 'MA', 'MG', 'MS', 'MT', 'PA',
+  'PB', 'PE', 'PI', 'PR', 'RJ', 'RN', 'RO', 'RR', 'RS', 'SC', 'SE', 'SP', 'TO',
+];
+
+/** Gera n status únicos por (document:uf), com a `source` indicada. */
+function fakeStatus(n: number, source: StatusSource): CollectedStatus[] {
+  const docs = [
+    DocumentType.NFe, DocumentType.NFCe, DocumentType.CTe, DocumentType.MDFe, DocumentType.DCe,
+  ];
   return Array.from({ length: n }, (_, i) => ({
-    document: DocumentType.NFe,
-    uf: 'SP' as const,
-    authorizer: 'SP' as const,
+    document: docs[Math.floor(i / UFS.length) % docs.length]!,
+    uf: UFS[i % UFS.length]!,
+    authorizer: 'SVRS' as const,
     state: ServiceState.Operational,
     cStat: 107,
     latencyMs: 0,
-  })).map((s, i) => ({ ...s, uf: (['SP', 'MG', 'RS'][i % 3] ?? 'SP') as never }));
+    source,
+  }));
 }
 
 describe('HybridCollector', () => {
   it('usa a fonte primária quando ela traz dados suficientes', async () => {
-    const primary: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120)) };
-    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(50)) };
+    const primary: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120, 'integranotas')) };
+    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(50, 'availability')) };
     const out = await new HybridCollector(primary, fallback, 100).collect();
     expect(out).toHaveLength(120);
     expect(fallback.collect).not.toHaveBeenCalled();
   });
 
-  it('cai para o fallback quando a primária traz poucos dados', async () => {
-    const primary: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(10)) };
-    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120)) };
+  it('mescla: primário parcial completa as lacunas com o fallback', async () => {
+    // primário traz só 10 (1ª década de chaves), fallback traz 120.
+    const primary: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(10, 'integranotas')) };
+    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120, 'availability')) };
     const out = await new HybridCollector(primary, fallback, 100).collect();
+    // união das chaves = 120 (o fallback cobre tudo que o primário tinha + o resto)
     expect(out).toHaveLength(120);
     expect(fallback.collect).toHaveBeenCalledOnce();
+    // as 10 chaves do primário mantêm a fonte primária (precedência)
+    const fromPrimary = out.filter((s) => s.source === 'integranotas');
+    expect(fromPrimary).toHaveLength(10);
   });
 
   it('cai para o fallback quando a primária lança', async () => {
@@ -37,9 +53,20 @@ describe('HybridCollector', () => {
         throw new Error('IntegraNotas fora do ar');
       }),
     };
-    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120)) };
+    const fallback: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(120, 'availability')) };
     const out = await new HybridCollector(primary, fallback, 100).collect();
     expect(out).toHaveLength(120);
     expect(fallback.collect).toHaveBeenCalledOnce();
+  });
+
+  it('fica com o primário parcial se o fallback também falhar', async () => {
+    const primary: StatusCollectorLike = { collect: vi.fn(async () => fakeStatus(10, 'integranotas')) };
+    const fallback: StatusCollectorLike = {
+      collect: vi.fn(async () => {
+        throw new Error('scraping fora do ar');
+      }),
+    };
+    const out = await new HybridCollector(primary, fallback, 100).collect();
+    expect(out).toHaveLength(10);
   });
 });

--- a/packages/core/test/integranotas/IntegraNotasProvider.test.ts
+++ b/packages/core/test/integranotas/IntegraNotasProvider.test.ts
@@ -44,6 +44,24 @@ describe('IntegraNotasProvider', () => {
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow();
   });
 
+  it('lança quando há labels/backgroundColor mas falta o array data', async () => {
+    // Sem essa guarda, todas as UFs virariam Error silenciosamente (tMed=-1) e o
+    // fallback do híbrido nunca dispararia.
+    const payload = JSON.stringify({
+      dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''] },
+    });
+    const provider = new IntegraNotasProvider(async () => payload);
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto/);
+  });
+
+  it('lança quando data tem comprimento diferente de labels', async () => {
+    const payload = JSON.stringify({
+      dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''], data: [1] },
+    });
+    const provider = new IntegraNotasProvider(async () => payload);
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto/);
+  });
+
   it('cobre os 5 documentos suportados', () => {
     const provider = new IntegraNotasProvider(async () => nfeFixture);
     const docs = provider.supportedDocuments();


### PR DESCRIPTION
## Contexto

Investigação que começou pelos gráficos online que pararam de funcionar e evoluiu para uma auditoria multi-lente do projeto. Foram identificados **16 achados** (verificados adversarialmente) e **todos foram corrigidos** nesta branch, com testes.

A coleta nunca parou — os bugs eram de cálculo/exibição e robustez. Duas causas-raiz explicavam a maioria:
1. **`latencyMs > 0` como proxy de "tem dado"** — mas é o "tempo médio" da SEFAZ em segundos inteiros, e 0 é legítimo.
2. **Definição divergente de "no ar"** — `OPERATIONAL` vs `OPERATIONAL||CONTINGENCY` espalhadas, dando números diferentes para a mesma frota.

## Commits (agrupados por tema)

1. **`fix(web)`** — inclui latência 0 nos gráficos (LatencyChart, sparkline, tooltip).
2. **`fix(web)`** — cobertura de uptime pela cadência real (~3h, não 1h); remove janelas '1h'/'6h'.
3. **`fix`** — unifica `isUp` e `averageLatency` em `@monitor-sefaz/contracts` e propaga nos 6 sítios (avgLatencyMs: 1000ms → ~326ms).
4. **`fix`** — robustez de ingestão: validação do payload IntegraNotas + parse resiliente por-elemento no front + fallback do HybridDataSource.
5. **`feat`** — campo `source` (tempo-médio vs latência-de-rede) + merge no HybridCollector + backoff no AvailabilityProvider + paginação por filtro + guarda de piso na coleta.

## Verificação

- Build do monorepo ✓ · Lint limpo
- **106 testes verdes** (eram 97; +9 cobrindo os helpers, schema resiliente, validação de payload, uptime com contingência e o merge do híbrido)
- Collector validado ponta a ponta: `avgLatencyMs = 326`, `source` gravado em status/history, guarda de piso aborta sem sobrescrever quando a cobertura é insuficiente

## Notas de revisão

- `source` é **opcional** nos schemas para compatibilidade com `history.json` já versionado (ausente = `integranotas`).
- `StatusReport` (core) mantém um `isUp` local espelho de propósito, para não acoplar o core ao pacote de contracts.
- Guarda de piso configurável por `MIN_COVERAGE_RATIO` (default 0.75 do catálogo).