### PR TITLE
feat: amplia fontes de status com consenso multi-fonte (SVRS) e frescor por serviço

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,11 +5,13 @@ PORT=3333
 REDIS_URL=redis://localhost:6379
 
 # Fonte de status:
-#   availability (padrão) = scraping da página oficial de disponibilidade
-#     (pública, NÃO exige certificado A1, funciona em qualquer rede)
+#   hybrid (padrão) = consenso multi-fonte com precedência oficial: SVRS e
+#     página oficial da Receita decidem o estado, o IntegraNotas preenche as
+#     lacunas (público, NÃO exige certificado A1, funciona em qualquer rede)
+#   availability = só o scraping da página oficial de disponibilidade
 #   soap = consulta SOAP direta aos webservices (dados mais ricos, exige
 #     saída de rede e, em vários autorizadores, certificado A1)
-STATUS_SOURCE=availability
+STATUS_SOURCE=hybrid
 
 # Agendamento das checagens (cron). Padrão: a cada 5 minutos.
 CRON_EXPRESSION=*/5 * * * *

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Veja [`.env.example`](.env.example). As principais:
 | Variável | Padrão | Uso |
 | -------- | ------ | --- |
 | `VITE_API_BASE_URL` | _(vazio)_ | Front: definido → API/Worker ao vivo; vazio → JSONs estáticos |
-| `STATUS_SOURCE` | `availability` | Self-host: `availability` (scraping) ou `soap` |
+| `STATUS_SOURCE` | `hybrid` | Self-host: `hybrid` (consenso multi-fonte), `availability` (só scraping) ou `soap` |
 | `REDIS_URL` | `redis://localhost:6379` | Self-host |
 | `SEFAZ_CERT_PATH` / `SEFAZ_CERT_PASSPHRASE` | _(vazio)_ | Certificado A1 para o modo `soap` (mTLS) |
 
@@ -123,7 +123,7 @@ Code. Interface em PT-BR; código, contratos e APIs em inglês.
 ```
 packages/
   catalog/     dados do MOC: UFs, cStat, endpoints e mapa UF→autorizador
-  core/        motor: AvailabilityCollector (scraping) + SOAP (Envelope/Parser/Checker)
+  core/        motor: consenso multi-fonte (SVRS + Receita + IntegraNotas) + SOAP (Envelope/Parser/Checker)
   contracts/   schemas Zod + DTOs compartilhados (single source of truth)
 apps/
   collector/   CLI → gera os JSONs versionados (usado pelo GitHub Actions)
@@ -132,10 +132,12 @@ apps/
   web/         React + Vite → status page (fonte de dados plugável)
 ```
 
-> **Como obtém os dados sem certificado:** a SEFAZ publica uma página oficial de
-> disponibilidade (`disponibilidade.aspx`), pública e sem mTLS. O monitor faz o
-> scraping dela — a mesma estratégia de monitores públicos. MDF-e e DC-e são
-> centralizados no SVRS, então derivam do estado desse autorizador.
+> **Como obtém os dados sem certificado:** o monitor cruza fontes públicas (sem
+> mTLS) por consenso com precedência oficial — o portal do **SVRS**
+> (`dfe-portal.svrs.rs.gov.br`) e a **página oficial da Receita**
+> (`disponibilidade.aspx`) decidem o estado de cada serviço; o **IntegraNotas**
+> (API JSON) preenche as UFs/documentos que as oficiais não publicam. MDF-e e
+> DC-e são centralizados no SVRS, então derivam do estado desse autorizador.
 
 ## 🧪 Testes
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -38,10 +38,11 @@ async function main(): Promise<void> {
     };
   }
 
-  // Seleciona a fonte de status. Padrão: híbrida (IntegraNotas + fallback), o
-  // MESMO motor do collector e do worker — assim os números batem entre as três
-  // pontas. Opt-in: 'soap' (consulta direta, exige cert A1) ou 'availability'
-  // (só scraping da página oficial).
+  // Seleciona a fonte de status. Padrão: consenso multi-fonte (SVRS e página
+  // oficial — oficiais — com o IntegraNotas preenchendo lacunas), o MESMO motor
+  // do collector e do worker — assim os números batem entre as três pontas.
+  // Opt-in: 'soap' (consulta direta, exige cert A1) ou 'availability' (só
+  // scraping da página oficial).
   let source: StatusSource;
   if (config.statusSource === 'soap') {
     const checker = CheckerFactory.create({

--- a/apps/api/src/sources/AvailabilityStatusSource.ts
+++ b/apps/api/src/sources/AvailabilityStatusSource.ts
@@ -44,6 +44,7 @@ export class AvailabilityStatusSource implements StatusSource {
       xMotivo: null,
       latencyMs: s.latencyMs,
       source: s.source,
+      sourceCheckedAt: s.sourceCheckedAt,
       error: null,
       checkedAt,
     };

--- a/apps/api/src/sources/HybridStatusSource.ts
+++ b/apps/api/src/sources/HybridStatusSource.ts
@@ -47,6 +47,7 @@ export class HybridStatusSource implements StatusSource {
       xMotivo: null,
       latencyMs: s.latencyMs,
       source: s.source,
+      sourceCheckedAt: s.sourceCheckedAt,
       error: null,
       checkedAt,
     };

--- a/apps/api/src/sources/HybridStatusSource.ts
+++ b/apps/api/src/sources/HybridStatusSource.ts
@@ -1,5 +1,5 @@
 import {
-  HybridCollector,
+  ConsensusCollector,
   type CollectedStatus,
   type StatusCollectorLike,
 } from '@monitor-sefaz/core';
@@ -9,18 +9,20 @@ import { serviceId } from '../store/mappers.js';
 import type { StatusSource } from './StatusSource.js';
 
 /**
- * Fonte de status HÍBRIDA: IntegraNotas (JSON, 5 docs por UF) com fallback ao
- * scraping oficial — o MESMO motor (`HybridCollector`) usado pelo collector
- * (GitHub Actions) e pelo Cloudflare Worker. É o default da API para que as três
- * pontas produzam números e semântica de latência idênticos para a mesma frota.
+ * Fonte de status padrão da API: o consenso multi-fonte com precedência oficial
+ * (`ConsensusCollector` — SVRS e página da Receita decidem o estado, o
+ * IntegraNotas preenche as lacunas), o MESMO motor usado pelo collector (GitHub
+ * Actions) e pelo Cloudflare Worker, para que as três pontas produzam os mesmos
+ * números para a mesma frota.
  *
+ * Mantém o nome `hybrid` por compatibilidade com a config `STATUS_SOURCE`.
  * A fonte é de PRODUÇÃO; homologação retorna vazio.
  */
 export class HybridStatusSource implements StatusSource {
   public readonly name = 'hybrid';
 
   constructor(
-    private readonly collector: StatusCollectorLike = HybridCollector.createForNode(),
+    private readonly collector: StatusCollectorLike = ConsensusCollector.createForNode(),
     private readonly now: () => number = () => Date.now()
   ) {}
 

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -1,6 +1,6 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { HybridCollector } from '@monitor-sefaz/core';
+import { ConsensusCollector } from '@monitor-sefaz/core';
 import { Catalog, DEFAULT_MIN_COVERAGE_RATIO, Environment } from '@monitor-sefaz/catalog';
 import {
   averageLatency,
@@ -109,9 +109,10 @@ async function main(): Promise<void> {
   mkdirSync(outDir, { recursive: true });
 
   const generatedAt = new Date().toISOString();
-  // Fonte híbrida: IntegraNotas (JSON, 5 docs por UF) com fallback ao scraping
-  // oficial da SEFAZ.
-  const collector = HybridCollector.createForNode();
+  // Fonte multi-fonte com precedência oficial: SVRS e página oficial da Receita
+  // (oficiais) decidem o estado; o IntegraNotas (mais completo) preenche as UFs
+  // que as oficiais não publicam.
+  const collector = ConsensusCollector.createForNode();
   const collected = await collector.collect();
 
   // Guarda de piso: se a coleta veio muito abaixo do catálogo, ambas as fontes

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -141,6 +141,7 @@ async function main(): Promise<void> {
     xMotivo: null,
     latencyMs: s.latencyMs,
     source: s.source,
+    sourceCheckedAt: s.sourceCheckedAt,
     error: null,
     checkedAt: generatedAt,
   }));

--- a/apps/web/src/components/ServiceCard.tsx
+++ b/apps/web/src/components/ServiceCard.tsx
@@ -95,6 +95,15 @@ export function ServiceCard({ service, spark = [], onSelect }: ServiceCardProps)
               </span>
             )}
           </div>
+          {service.sourceCheckedAt && (
+            <p
+              className="mt-1 cursor-help text-[10px]"
+              style={{ color: 'var(--text-dim)' }}
+              title="Horário em que o próprio autorizador (SVRS) verificou o serviço — o frescor do dado oficial."
+            >
+              ✓ aferido pela SEFAZ às {service.sourceCheckedAt.slice(0, 5)}
+            </p>
+          )}
         </div>
         <Icon
           className="h-8 w-8 shrink-0 opacity-20 transition-opacity duration-300 group-hover:opacity-90"

--- a/apps/web/test/ServiceCard.test.tsx
+++ b/apps/web/test/ServiceCard.test.tsx
@@ -47,4 +47,14 @@ describe('ServiceCard', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(onSelect).toHaveBeenCalledOnce();
   });
+
+  it('mostra o frescor "aferido pela SEFAZ" quando há sourceCheckedAt (HH:MM)', () => {
+    render(<ServiceCard service={service({ sourceCheckedAt: '17:33:53' })} onSelect={() => {}} />);
+    expect(screen.getByText(/aferido pela SEFAZ às 17:33/)).toBeInTheDocument();
+  });
+
+  it('omite o frescor quando a fonte não publica sourceCheckedAt', () => {
+    render(<ServiceCard service={service()} onSelect={() => {}} />);
+    expect(screen.queryByText(/aferido pela SEFAZ/)).not.toBeInTheDocument();
+  });
 });

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -98,6 +98,7 @@ function toDTO(s: CollectedStatus, checkedAt: string): ServiceStatusDTO {
     xMotivo: null,
     latencyMs: s.latencyMs,
     source: s.source,
+    sourceCheckedAt: s.sourceCheckedAt,
     error: null,
     checkedAt,
   };

--- a/apps/worker/src/index.ts
+++ b/apps/worker/src/index.ts
@@ -1,9 +1,12 @@
 import {
   AvailabilityCollector,
-  HybridCollector,
+  ConsensusCollector,
   IntegraNotasCollector,
+  SvrsCollector,
+  SvrsProvider,
   type CollectedStatus,
   type IntegraNotasFetcher,
+  type SvrsFetcher,
 } from '@monitor-sefaz/core';
 import {
   averageLatency,
@@ -32,12 +35,46 @@ const integraNotasFetcher: IntegraNotasFetcher = async (url) => {
   return res.text();
 };
 
-/** Híbrido do Worker: IntegraNotas (JSON) com fallback ao scraping oficial. */
-function buildCollector(): HybridCollector {
-  return new HybridCollector(
-    IntegraNotasCollector.create(integraNotasFetcher),
-    new AvailabilityCollector(new WorkerAvailabilityProvider())
-  );
+/** Fetcher do SVRS no runtime do Worker (fetch nativo, página latin-1). */
+const svrsFetcher: SvrsFetcher = async (url) => {
+  const res = await fetch(url, {
+    headers: {
+      'User-Agent':
+        'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36',
+      Accept: 'text/html,application/xhtml+xml',
+      'Accept-Language': 'pt-BR,pt;q=0.9',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`SVRS HTTP ${res.status}`);
+  }
+  // A página é latin-1; o Worker não tem Buffer, decodificamos via TextDecoder.
+  return new TextDecoder('latin1').decode(await res.arrayBuffer());
+};
+
+/**
+ * Consenso do Worker (precedência oficial): SVRS e página oficial decidem o
+ * estado; o IntegraNotas (mais completo) preenche o resto. Se o SVRS falhar no
+ * runtime do Worker, o consenso (`allSettled`) o ignora sem derrubar a coleta.
+ */
+function buildCollector(): ConsensusCollector {
+  return new ConsensusCollector([
+    {
+      name: 'svrs',
+      official: true,
+      collector: new SvrsCollector(new SvrsProvider(svrsFetcher)),
+    },
+    {
+      name: 'availability',
+      official: true,
+      collector: new AvailabilityCollector(new WorkerAvailabilityProvider()),
+    },
+    {
+      name: 'integranotas',
+      official: false,
+      collector: IntegraNotasCollector.create(integraNotasFetcher),
+    },
+  ]);
 }
 
 const CORS = {

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -58,7 +58,12 @@ export const serviceStatusSchema = z.object({
   latencyMs: z.number(),
   source: statusSourceSchema.optional(),
   error: z.string().nullable(),
-  checkedAt: z.string(), // ISO 8601
+  checkedAt: z.string(), // ISO 8601 — quando o MONITOR coletou
+  /**
+   * Horário "HH:MM:SS" em que a própria FONTE verificou o serviço (frescor do
+   * dado oficial). Hoje só o SVRS publica; ausente nas demais fontes.
+   */
+  sourceCheckedAt: z.string().optional(),
 });
 export type ServiceStatusDTO = z.infer<typeof serviceStatusSchema>;
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -18,12 +18,16 @@ export const serviceStateSchema = z.enum([
 export type ServiceStateValue = z.infer<typeof serviceStateSchema>;
 
 /**
- * Origem da medição. Em ambas, `latencyMs` é a latência de REDE real do fetch
- * (ms) — `integranotas` (API JSON, primária) e `availability` (scraping) só
- * diferem na fonte. Opcional para compatibilidade com dados gravados antes deste
- * campo; ausente é tratado como `integranotas` (a fonte primária e dominante).
+ * Origem da medição que VENCEU o consenso por serviço:
+ * - `svrs` / `availability`: fontes OFICIAIS (portal SVRS e portal da Receita),
+ *   com precedência de estado. `svrs` traz `cStat` real e não mede latência de
+ *   rede (pode herdá-la de outra fonte no consenso).
+ * - `integranotas`: terceiro mais completo; preenche serviços que as oficiais não
+ *   publicam. `latencyMs` aqui é a latência de REDE real do fetch (ms).
+ * Opcional para compatibilidade com dados gravados antes deste campo; ausente é
+ * tratado como `integranotas`.
  */
-export const statusSourceSchema = z.enum(['integranotas', 'availability']);
+export const statusSourceSchema = z.enum(['integranotas', 'availability', 'svrs']);
 export type StatusSourceValue = z.infer<typeof statusSourceSchema>;
 
 /** Ambiente em formato textual usado na API (contrato em inglês). */

--- a/packages/core/src/availability/AvailabilityCollector.ts
+++ b/packages/core/src/availability/AvailabilityCollector.ts
@@ -47,6 +47,13 @@ export interface CollectedStatus {
   /** Latência (ms); a semântica depende de `source` — ver {@link StatusSource}. */
   readonly latencyMs: number;
   readonly source: StatusSource;
+  /**
+   * Horário "HH:MM:SS" em que a PRÓPRIA fonte verificou o serviço, quando ela o
+   * publica (hoje só o SVRS). É o frescor real do dado oficial — distinto do
+   * `checkedAt` do snapshot (quando o monitor coletou). Ausente nas fontes que
+   * não expõem essa informação.
+   */
+  readonly sourceCheckedAt?: string;
 }
 
 /**

--- a/packages/core/src/availability/AvailabilityCollector.ts
+++ b/packages/core/src/availability/AvailabilityCollector.ts
@@ -35,7 +35,7 @@ function stateToCStat(state: ServiceState): number | null {
  * página oficial) só diferem na fonte, não na grandeza. Mantido para rastrear a
  * procedência do dado.
  */
-export type StatusSource = 'integranotas' | 'availability';
+export type StatusSource = 'integranotas' | 'availability' | 'svrs';
 
 /** Status coletado de um serviço (documento + UF), pronto para virar DTO. */
 export interface CollectedStatus {

--- a/packages/core/src/consensus/ConsensusCollector.ts
+++ b/packages/core/src/consensus/ConsensusCollector.ts
@@ -1,0 +1,111 @@
+import { Catalog } from '@monitor-sefaz/catalog';
+import {
+  AvailabilityCollector,
+  type CollectedStatus,
+} from '../availability/AvailabilityCollector.js';
+import { HttpAvailabilityProvider } from '../availability/AvailabilityProvider.js';
+import { IntegraNotasCollector } from '../integranotas/IntegraNotasCollector.js';
+import { createHttpIntegraNotasFetcher } from '../integranotas/httpFetcher.js';
+import { SvrsCollector } from '../svrs/SvrsCollector.js';
+import { SvrsProvider } from '../svrs/SvrsProvider.js';
+import { createHttpSvrsFetcher } from '../svrs/httpFetcher.js';
+import type { StatusCollectorLike } from '../integranotas/HybridCollector.js';
+
+/** Uma fonte do consenso e se ela é OFICIAL (tem precedência de estado). */
+export interface ConsensusSource {
+  readonly collector: StatusCollectorLike;
+  /** Oficial (SVRS/Receita) vence o estado; não-oficial só preenche lacunas. */
+  readonly official: boolean;
+  /** Rótulo para logs/diagnóstico. */
+  readonly name: string;
+}
+
+/**
+ * Coletor MULTI-FONTE com PRECEDÊNCIA OFICIAL.
+ *
+ * Substitui o `HybridCollector` (que era failover A→B) por um cruzamento real:
+ * coleta todas as fontes em paralelo e, por serviço (`document:uf`), aplica:
+ *
+ * 1. A primeira fonte OFICIAL (na ordem dada) que reporta o serviço define o
+ *    `state`/`cStat`/`source` — é a verdade-fonte.
+ * 2. Fontes não-oficiais só PREENCHEM serviços que nenhuma oficial cobre (o
+ *    IntegraNotas, mais completo, completa as UFs que o SVRS/Receita não listam).
+ * 3. A `latencyMs` da fonte vencedora é mantida; se ela for 0 (o SVRS não publica
+ *    latência de rede), HERDA a latência de outra fonte que mediu o mesmo serviço,
+ *    para não regredir a métrica de latência exibida.
+ *
+ * Uma fonte que lança/zera não derruba as demais (`allSettled`).
+ */
+export class ConsensusCollector implements StatusCollectorLike {
+  public readonly name = 'consensus';
+
+  constructor(private readonly sources: ConsensusSource[]) {}
+
+  /**
+   * Consenso padrão para Node, em ordem de precedência:
+   * SVRS (oficial) → página oficial da Receita (oficial) → IntegraNotas (terceiro,
+   * mais completo). Mesmo motor para api, collector (Actions) e — quando portado —
+   * o Worker.
+   */
+  public static createForNode(catalog = new Catalog()): ConsensusCollector {
+    return new ConsensusCollector([
+      {
+        name: 'svrs',
+        official: true,
+        collector: new SvrsCollector(new SvrsProvider(createHttpSvrsFetcher()), catalog),
+      },
+      {
+        name: 'availability',
+        official: true,
+        collector: new AvailabilityCollector(new HttpAvailabilityProvider(), catalog),
+      },
+      {
+        name: 'integranotas',
+        official: false,
+        collector: IntegraNotasCollector.create(createHttpIntegraNotasFetcher(), catalog),
+      },
+    ]);
+  }
+
+  public async collect(): Promise<CollectedStatus[]> {
+    const settled = await Promise.allSettled(this.sources.map((s) => s.collector.collect()));
+    const results = settled.map((r, i) => ({
+      source: this.sources[i]!,
+      statuses: r.status === 'fulfilled' ? r.value : [],
+    }));
+
+    const key = (s: CollectedStatus): string => `${s.document}:${s.uf}`;
+    const winners = new Map<string, CollectedStatus>();
+    // Latência REAL medida por qualquer fonte (para herança quando a vencedora é 0).
+    const measuredLatency = new Map<string, number>();
+
+    // Primeiro passe: registra a melhor latência real conhecida de cada serviço.
+    for (const { statuses } of results) {
+      for (const s of statuses) {
+        if (s.latencyMs > 0 && !measuredLatency.has(key(s))) {
+          measuredLatency.set(key(s), s.latencyMs);
+        }
+      }
+    }
+
+    // Precedência: oficiais primeiro (na ordem dada), depois não-oficiais. Dentro
+    // de cada grupo, a primeira fonte a reportar um serviço vence; as seguintes
+    // não sobrescrevem.
+    const ordered = [
+      ...results.filter((r) => r.source.official),
+      ...results.filter((r) => !r.source.official),
+    ];
+    for (const { statuses } of ordered) {
+      for (const s of statuses) {
+        const k = key(s);
+        if (winners.has(k)) {
+          continue; // já decidido por uma fonte de maior precedência
+        }
+        const latencyMs = s.latencyMs > 0 ? s.latencyMs : (measuredLatency.get(k) ?? 0);
+        winners.set(k, latencyMs === s.latencyMs ? s : { ...s, latencyMs });
+      }
+    }
+
+    return [...winners.values()];
+  }
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -76,3 +76,14 @@ export {
 export { IntegraNotasCollector } from './integranotas/IntegraNotasCollector.js';
 export { createHttpIntegraNotasFetcher } from './integranotas/httpFetcher.js';
 export { HybridCollector, type StatusCollectorLike } from './integranotas/HybridCollector.js';
+
+// Fonte SVRS (portal oficial de disponibilidade — sem certificado A1)
+export {
+  SvrsParser,
+  type SvrsAuthorizer,
+  type SvrsWebService,
+  type SvrsAuthorizerStatus,
+} from './svrs/SvrsParser.js';
+export { SvrsProvider, SVRS_URLS, type SvrsFetcher } from './svrs/SvrsProvider.js';
+export { createHttpSvrsFetcher } from './svrs/httpFetcher.js';
+export { SvrsCollector } from './svrs/SvrsCollector.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -87,3 +87,6 @@ export {
 export { SvrsProvider, SVRS_URLS, type SvrsFetcher } from './svrs/SvrsProvider.js';
 export { createHttpSvrsFetcher } from './svrs/httpFetcher.js';
 export { SvrsCollector } from './svrs/SvrsCollector.js';
+
+// Consenso multi-fonte (precedência oficial)
+export { ConsensusCollector, type ConsensusSource } from './consensus/ConsensusCollector.js';

--- a/packages/core/src/svrs/SvrsCollector.ts
+++ b/packages/core/src/svrs/SvrsCollector.ts
@@ -1,0 +1,98 @@
+import {
+  Catalog,
+  CSTAT_DOWN,
+  CSTAT_OPERATIONAL,
+  CSTAT_SLOWDOWN,
+  Environment,
+  type AuthorizerCode,
+  type DocumentType,
+} from '@monitor-sefaz/catalog';
+import { ServiceState } from '../domain/types.js';
+import type { CollectedStatus } from '../availability/AvailabilityCollector.js';
+import type { SvrsProvider } from './SvrsProvider.js';
+import type { SvrsAuthorizer, SvrsAuthorizerStatus } from './SvrsParser.js';
+
+function stateToCStat(state: ServiceState): number | null {
+  switch (state) {
+    case ServiceState.Operational:
+    case ServiceState.Contingency:
+      return CSTAT_OPERATIONAL; // 107
+    case ServiceState.SlowDown:
+      return CSTAT_SLOWDOWN; // 108
+    case ServiceState.Down:
+      return CSTAT_DOWN; // 109
+    default:
+      return null;
+  }
+}
+
+/** Mapeia o autorizador do portal SVRS para o `AuthorizerCode` do catálogo. */
+function toAuthorizerCode(a: SvrsAuthorizer): AuthorizerCode {
+  return a === 'SEFAZ-RS' ? 'RS' : 'SVRS';
+}
+
+/**
+ * Coletor de status baseado no portal OFICIAL de disponibilidade do SVRS.
+ *
+ * O SVRS publica o status por AUTORIZADOR (SEFAZ-RS e o SVRS nacional), não por
+ * UF — então expandimos autorizador→UF via `Catalog`, igual ao
+ * `AvailabilityCollector`. Cobre as UFs que usam o SVRS como autorizador e os
+ * documentos MDF-e/DC-e (nacionais no SVRS). É fonte oficial e independente do
+ * IntegraNotas, com `cStat` real — ideal como fonte de PRECEDÊNCIA no consenso.
+ */
+export class SvrsCollector {
+  public readonly name = 'svrs';
+
+  constructor(
+    private readonly provider: SvrsProvider,
+    private readonly catalog = new Catalog()
+  ) {}
+
+  public async collect(): Promise<CollectedStatus[]> {
+    const out: CollectedStatus[] = [];
+
+    for (const document of this.provider.supportedDocuments()) {
+      let authorizers: SvrsAuthorizerStatus[];
+      try {
+        authorizers = await this.provider.fetch(document);
+      } catch {
+        continue; // documento que falha não derruba os demais
+      }
+
+      const byCode = new Map<AuthorizerCode, SvrsAuthorizerStatus>(
+        authorizers.map((a) => [toAuthorizerCode(a.authorizer), a])
+      );
+      out.push(...this.expand(document, byCode));
+    }
+
+    return out;
+  }
+
+  /** Expande o status por-autorizador do SVRS para status por-UF. */
+  private expand(
+    document: DocumentType,
+    byCode: Map<AuthorizerCode, SvrsAuthorizerStatus>
+  ): CollectedStatus[] {
+    const out: CollectedStatus[] = [];
+    for (const entry of this.catalog.list(document, Environment.Production)) {
+      const status = byCode.get(entry.authorizer);
+      if (!status) {
+        continue; // UF cujo autorizador o SVRS não publica
+      }
+      out.push({
+        document: entry.document,
+        uf: entry.uf,
+        authorizer: entry.authorizer,
+        state: status.state,
+        // Preferimos o cStat REAL do SVRS; se ausente, derivamos do estado.
+        cStat: status.cStat ?? stateToCStat(status.state),
+        // O SVRS não publica latência de rede; mantemos 0 (o consenso pode
+        // herdar a latência de outra fonte). O timestamp do SVRS fica em
+        // `sourceCheckedAt` para o front exibir frescor — ver mapeamento no DTO.
+        latencyMs: 0,
+        source: 'svrs',
+      });
+    }
+    return out;
+  }
+}

--- a/packages/core/src/svrs/SvrsCollector.ts
+++ b/packages/core/src/svrs/SvrsCollector.ts
@@ -87,10 +87,11 @@ export class SvrsCollector {
         // Preferimos o cStat REAL do SVRS; se ausente, derivamos do estado.
         cStat: status.cStat ?? stateToCStat(status.state),
         // O SVRS não publica latência de rede; mantemos 0 (o consenso pode
-        // herdar a latência de outra fonte). O timestamp do SVRS fica em
-        // `sourceCheckedAt` para o front exibir frescor — ver mapeamento no DTO.
+        // herdar a latência de outra fonte). O timestamp do SVRS vira o frescor
+        // exibido pelo front.
         latencyMs: 0,
         source: 'svrs',
+        sourceCheckedAt: status.lastCheckTime ?? undefined,
       });
     }
     return out;

--- a/packages/core/src/svrs/SvrsParser.ts
+++ b/packages/core/src/svrs/SvrsParser.ts
@@ -1,0 +1,169 @@
+import * as cheerio from 'cheerio';
+import { ServiceState } from '../domain/types.js';
+
+/**
+ * Autorizador exposto na página de disponibilidade do SVRS. A página da NF-e tem
+ * duas seções (SEFAZ-RS e SVRS); as de CT-e/MDF-e têm só o autorizador virtual.
+ */
+export type SvrsAuthorizer = 'SEFAZ-RS' | 'SVRS';
+
+/** Status de UM webservice (operação) de um autorizador, como o SVRS publica. */
+export interface SvrsWebService {
+  /** Operação, ex.: "WS Autorizacao", "WS Status", "WS Consulta Situacao". */
+  readonly operation: string;
+  readonly state: ServiceState;
+  /** `cStat` reportado pelo SVRS (107/106/215/...), ou null se ausente. */
+  readonly cStat: number | null;
+  /** Horário "HH:MM:SS" da última verificação do SVRS, ou null. */
+  readonly lastCheckTime: string | null;
+}
+
+/** Status agregado de um autorizador (todos os WS daquela seção). */
+export interface SvrsAuthorizerStatus {
+  readonly authorizer: SvrsAuthorizer;
+  /** Estado geral do autorizador, derivado dos seus webservices. */
+  readonly state: ServiceState;
+  /** `cStat` do "WS Status" (consulta de status do serviço), quando presente. */
+  readonly cStat: number | null;
+  /** Horário "HH:MM:SS" mais recente entre os WS do autorizador. */
+  readonly lastCheckTime: string | null;
+  readonly webServices: SvrsWebService[];
+}
+
+/**
+ * Mapeia a cor do ícone de status do SVRS para um `ServiceState`. O SVRS usa um
+ * `<i class="fa fa-check-circle" style="color: #3c763d">` (verde) para normal e
+ * cores quentes para degradação/erro.
+ */
+function colorToState(style: string): ServiceState {
+  const s = style.toLowerCase();
+  if (s.includes('#3c763d') || s.includes('3c763d')) return ServiceState.Operational; // verde
+  if (s.includes('#8a6d3b') || s.includes('#f0ad4e') || s.includes('orange') || s.includes('#ec971f')) {
+    return ServiceState.SlowDown; // âmbar/laranja — degradação
+  }
+  if (s.includes('#a94442') || s.includes('#d9534f') || s.includes('red')) {
+    return ServiceState.Down; // vermelho — parada
+  }
+  return ServiceState.Error;
+}
+
+/** Agrega o estado de um autorizador a partir dos seus webservices. */
+function aggregateState(webServices: SvrsWebService[]): ServiceState {
+  if (webServices.length === 0) return ServiceState.Error;
+  // Pior caso vence (conservador): se qualquer WS caiu, o autorizador não está
+  // 100%. Ordem de severidade: Down > SlowDown > Error > Operational.
+  if (webServices.some((w) => w.state === ServiceState.Down)) return ServiceState.Down;
+  if (webServices.some((w) => w.state === ServiceState.SlowDown)) return ServiceState.SlowDown;
+  if (webServices.every((w) => w.state === ServiceState.Operational)) return ServiceState.Operational;
+  // Algum WS em Error mas nenhum Down/SlowDown: trata como degradação.
+  return webServices.some((w) => w.state === ServiceState.Operational)
+    ? ServiceState.SlowDown
+    : ServiceState.Error;
+}
+
+const CSTAT_RE = /CStat:\s*(\d+)/i;
+const TIME_RE = /(\d{2}:\d{2}:\d{2})/;
+/** Nome da operação de status do serviço — usado para o cStat representativo. */
+const STATUS_OP_RE = /\bWS\s+Status\b/i;
+
+/**
+ * Parser da página pública de disponibilidade do SVRS
+ * (`dfe-portal.svrs.rs.gov.br/<Doc>/Disponibilidade`).
+ *
+ * Diferente da página oficial da Receita (bolinhas coloridas por coluna), o SVRS
+ * renderiza, por autorizador, uma tabela com uma linha por webservice contendo o
+ * nome da operação, um ícone colorido de status, o `cStat` real e o horário da
+ * última verificação. É fonte OFICIAL e não exige certificado A1.
+ *
+ * Layout observado:
+ * - NF-e: duas seções `<h4>SEFAZ-RS</h4>` e `<h4>SEFAZ Virtual do RS</h4>`, cada
+ *   uma com sua `<table>` de webservices.
+ * - CT-e/MDF-e: uma única tabela de webservices (só o autorizador virtual SVRS).
+ */
+export class SvrsParser {
+  public parse(html: string): SvrsAuthorizerStatus[] {
+    const $ = cheerio.load(html);
+    const out: SvrsAuthorizerStatus[] = [];
+
+    // Cada bloco "col-sm-6" com um <h4> identifica uma seção de autorizador (NF-e).
+    // Quando não há <h4> (CT-e/MDF-e), a página inteira é o autorizador SVRS.
+    const headers = $('h4').toArray();
+    let matchedSection = false;
+    for (const h of headers) {
+      const authorizer = titleToAuthorizer($(h).text().trim());
+      if (!authorizer) {
+        continue;
+      }
+      matchedSection = true;
+      // A tabela de WS é a primeira <table> dentro da mesma coluna do <h4>.
+      const table = $(h).closest('.col-sm-6').find('table').first();
+      const webServices = this.parseWebServices($, table);
+      if (webServices.length > 0) {
+        out.push(this.toAuthorizerStatus(authorizer, webServices));
+      }
+    }
+
+    if (matchedSection) {
+      return out;
+    }
+
+    // Sem <h4> de autorizador: assume a primeira tabela de webservices como SVRS.
+    const table = $('table.table-hover').first();
+    const webServices = this.parseWebServices($, table);
+    if (webServices.length > 0) {
+      out.push(this.toAuthorizerStatus('SVRS', webServices));
+    }
+    return out;
+  }
+
+  private parseWebServices(
+    $: cheerio.CheerioAPI,
+    table: ReturnType<cheerio.CheerioAPI>
+  ): SvrsWebService[] {
+    const webServices: SvrsWebService[] = [];
+    table.find('tr').each((_, tr) => {
+      const cells = $(tr).find('td');
+      if (cells.length < 2) return;
+
+      const label = cells.eq(1).find('b').first().text().trim();
+      if (!/^WS\s+/i.test(label)) return; // não é uma linha de webservice
+
+      const detail = cells.eq(1).text();
+      const cStatMatch = detail.match(CSTAT_RE);
+      const timeMatch = detail.match(TIME_RE);
+      const style = cells.eq(0).find('i').attr('style') ?? '';
+
+      webServices.push({
+        operation: label,
+        state: colorToState(style),
+        cStat: cStatMatch?.[1] ? Number.parseInt(cStatMatch[1], 10) : null,
+        lastCheckTime: timeMatch?.[1] ?? null,
+      });
+    });
+    return webServices;
+  }
+
+  private toAuthorizerStatus(
+    authorizer: SvrsAuthorizer,
+    webServices: SvrsWebService[]
+  ): SvrsAuthorizerStatus {
+    const statusWs = webServices.find((w) => STATUS_OP_RE.test(w.operation));
+    const times = webServices.map((w) => w.lastCheckTime).filter((t): t is string => t !== null);
+    return {
+      authorizer,
+      state: aggregateState(webServices),
+      // cStat representativo: o do "WS Status"; senão o primeiro disponível.
+      cStat: statusWs?.cStat ?? webServices.find((w) => w.cStat !== null)?.cStat ?? null,
+      lastCheckTime: times.length > 0 ? times.sort().at(-1)! : null,
+      webServices,
+    };
+  }
+}
+
+/** Mapeia o título da seção SVRS para o autorizador canônico. */
+function titleToAuthorizer(title: string): SvrsAuthorizer | null {
+  const t = title.toUpperCase();
+  if (t.includes('SEFAZ-RS') || t === 'SEFAZ RS') return 'SEFAZ-RS';
+  if (t.includes('VIRTUAL') || t.includes('SVRS')) return 'SVRS';
+  return null;
+}

--- a/packages/core/src/svrs/SvrsProvider.ts
+++ b/packages/core/src/svrs/SvrsProvider.ts
@@ -1,0 +1,82 @@
+import { DocumentType } from '@monitor-sefaz/catalog';
+import { backoffMs, type Sleeper } from '../availability/AvailabilityProvider.js';
+import { SvrsParser, type SvrsAuthorizerStatus } from './SvrsParser.js';
+
+/**
+ * URLs de PRODUÇÃO do portal de disponibilidade do SVRS, por documento. NF-e e
+ * NFC-e compartilham a página da NF-e; DC-e roda no SVRS e usa a página da MDF-e
+ * como melhor proxy oficial disponível (ambos são serviços do SVRS nacional).
+ *
+ * Diferente do `hom.` da Receita, o SVRS não separa o portal por ambiente aqui —
+ * estas páginas refletem a disponibilidade de produção.
+ */
+export const SVRS_URLS: Partial<Record<DocumentType, string>> = {
+  [DocumentType.NFe]: 'https://dfe-portal.svrs.rs.gov.br/Nfe/Disponibilidade',
+  [DocumentType.NFCe]: 'https://dfe-portal.svrs.rs.gov.br/Nfe/Disponibilidade',
+  [DocumentType.CTe]: 'https://dfe-portal.svrs.rs.gov.br/Cte/Disponibilidade',
+  [DocumentType.MDFe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
+  [DocumentType.DCe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
+};
+
+const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Transporte HTTP injetável (axios no Node via `createHttpSvrsFetcher`, fetch
+ * nativo no Worker). Devolve o HTML já decodificado. É injetado — e não default —
+ * de propósito: assim o bundle do Worker NÃO arrasta axios/tough-cookie (APIs de
+ * Node), mesmo importação do `SvrsProvider`.
+ */
+export interface SvrsFetcher {
+  (url: string): Promise<string>;
+}
+
+/**
+ * Cliente da página pública de disponibilidade do SVRS — fonte OFICIAL que NÃO
+ * exige certificado A1. O transporte é injetado; o provider só cuida do retry com
+ * backoff (o portal é ASP.NET e ocasionalmente recusa a conexão) e do parse.
+ */
+export class SvrsProvider {
+  private readonly parser = new SvrsParser();
+
+  constructor(
+    private readonly fetcher: SvrsFetcher,
+    private readonly sleep: Sleeper = defaultSleeper,
+    private readonly random: () => number = Math.random
+  ) {}
+
+  /** Documentos que o SVRS cobre (todos os 5, via autorizador SVRS/SEFAZ-RS). */
+  public supportedDocuments(): DocumentType[] {
+    return Object.keys(SVRS_URLS) as DocumentType[];
+  }
+
+  /**
+   * Busca e parseia a disponibilidade de um documento. Tenta algumas vezes com
+   * backoff; se todas falharem ou não trouxerem autorizadores, LANÇA — assim o
+   * `SvrsCollector` omite o documento e o consenso cai na próxima fonte (parse
+   * estrito, como nas demais fontes ao vivo).
+   */
+  public async fetch(document: DocumentType, attempts = 3): Promise<SvrsAuthorizerStatus[]> {
+    const url = SVRS_URLS[document];
+    if (!url) {
+      return [];
+    }
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const html = await this.fetcher(url);
+        const rows = this.parser.parse(html);
+        if (rows.length > 0) {
+          return rows;
+        }
+        lastError = new Error('SVRS: resposta sem autorizadores');
+      } catch (err) {
+        lastError = err;
+      }
+      if (attempt < attempts) {
+        await this.sleep(backoffMs(attempt, this.random));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+}

--- a/packages/core/src/svrs/httpFetcher.ts
+++ b/packages/core/src/svrs/httpFetcher.ts
@@ -1,0 +1,37 @@
+import axios, { type AxiosInstance } from 'axios';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+import type { SvrsFetcher } from './SvrsProvider.js';
+
+const BROWSER_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36';
+
+/**
+ * Fetcher do SVRS para Node (axios + cookie jar). O portal usa o esquema ASP.NET
+ * `AspxAutoDetectCookieSupport` — sem cookie jar entra em loop de redirect —, por
+ * isso a mesma estratégia do `HttpAvailabilityProvider`. A página é latin-1.
+ *
+ * ISOLADO em arquivo próprio (e não default do provider) para que o Worker possa
+ * importar o `SvrsProvider` sem puxar axios/tough-cookie para o seu bundle.
+ */
+export function createHttpSvrsFetcher(timeoutMs = 20_000): SvrsFetcher {
+  const jar = new CookieJar();
+  const http: AxiosInstance = wrapper(
+    axios.create({
+      jar,
+      timeout: timeoutMs,
+      maxRedirects: 15,
+      responseType: 'arraybuffer',
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'pt-BR,pt;q=0.9',
+      },
+      validateStatus: () => true,
+    })
+  );
+  return async (url) => {
+    const res = await http.get<ArrayBuffer>(url);
+    return Buffer.from(res.data).toString('latin1');
+  };
+}

--- a/packages/core/test/consensus/ConsensusCollector.test.ts
+++ b/packages/core/test/consensus/ConsensusCollector.test.ts
@@ -10,9 +10,10 @@ function status(
   state: ServiceState,
   source: CollectedStatus['source'],
   latencyMs = 0,
-  document = DocumentType.NFe
+  document = DocumentType.NFe,
+  sourceCheckedAt?: string
 ): CollectedStatus {
-  return { document, uf, authorizer: uf, state, cStat: null, latencyMs, source };
+  return { document, uf, authorizer: uf, state, cStat: null, latencyMs, source, sourceCheckedAt };
 }
 
 /** Collector que devolve uma lista fixa (ou lança, se `fail`). */
@@ -70,8 +71,10 @@ describe('ConsensusCollector', () => {
     expect(out[0]!.state).toBe(ServiceState.Down);
   });
 
-  it('herda a latência real medida quando a fonte vencedora reporta 0', async () => {
-    const official = fake([status('SP', ServiceState.Operational, 'svrs', 0)]); // SVRS não mede latência
+  it('herda a latência real medida quando a fonte vencedora reporta 0, preservando sourceCheckedAt', async () => {
+    const official = fake([
+      status('SP', ServiceState.Operational, 'svrs', 0, DocumentType.NFe, '17:33:53'), // SVRS não mede latência
+    ]);
     const third = fake([status('SP', ServiceState.Operational, 'integranotas', 250)]);
     const consensus = new ConsensusCollector([
       { name: 'svrs', official: true, collector: official },
@@ -81,6 +84,7 @@ describe('ConsensusCollector', () => {
     const out = await consensus.collect();
     expect(out[0]!.source).toBe('svrs'); // estado é o oficial
     expect(out[0]!.latencyMs).toBe(250); // latência herdada da fonte que mediu
+    expect(out[0]!.sourceCheckedAt).toBe('17:33:53'); // frescor do SVRS preservado na herança
   });
 
   it('uma fonte que lança não derruba as demais', async () => {

--- a/packages/core/test/consensus/ConsensusCollector.test.ts
+++ b/packages/core/test/consensus/ConsensusCollector.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from 'vitest';
+import { DocumentType, type UF } from '@monitor-sefaz/catalog';
+import { ConsensusCollector } from '../../src/consensus/ConsensusCollector.js';
+import { ServiceState } from '../../src/domain/types.js';
+import type { CollectedStatus } from '../../src/availability/AvailabilityCollector.js';
+import type { StatusCollectorLike } from '../../src/integranotas/HybridCollector.js';
+
+function status(
+  uf: UF,
+  state: ServiceState,
+  source: CollectedStatus['source'],
+  latencyMs = 0,
+  document = DocumentType.NFe
+): CollectedStatus {
+  return { document, uf, authorizer: uf, state, cStat: null, latencyMs, source };
+}
+
+/** Collector que devolve uma lista fixa (ou lança, se `fail`). */
+function fake(rows: CollectedStatus[], fail = false): StatusCollectorLike {
+  return {
+    collect: async () => {
+      if (fail) throw new Error('fonte caiu');
+      return rows;
+    },
+  };
+}
+
+describe('ConsensusCollector', () => {
+  it('a fonte oficial vence o estado quando há divergência', async () => {
+    const official = fake([status('SP', ServiceState.SlowDown, 'svrs')]);
+    const third = fake([status('SP', ServiceState.Operational, 'integranotas')]);
+    const consensus = new ConsensusCollector([
+      { name: 'svrs', official: true, collector: official },
+      { name: 'integranotas', official: false, collector: third },
+    ]);
+
+    const out = await consensus.collect();
+    expect(out).toHaveLength(1);
+    expect(out[0]!.state).toBe(ServiceState.SlowDown);
+    expect(out[0]!.source).toBe('svrs');
+  });
+
+  it('a fonte não-oficial preenche serviços que a oficial não cobre', async () => {
+    const official = fake([status('SP', ServiceState.Operational, 'svrs')]);
+    const third = fake([
+      status('SP', ServiceState.Down, 'integranotas'), // ignorado: oficial cobre SP
+      status('AM', ServiceState.Operational, 'integranotas'), // usado: oficial não cobre AM
+    ]);
+    const consensus = new ConsensusCollector([
+      { name: 'svrs', official: true, collector: official },
+      { name: 'integranotas', official: false, collector: third },
+    ]);
+
+    const byUf = new Map((await consensus.collect()).map((s) => [s.uf, s]));
+    expect(byUf.get('SP')!.source).toBe('svrs');
+    expect(byUf.get('AM')!.source).toBe('integranotas');
+    expect(byUf.size).toBe(2);
+  });
+
+  it('a primeira fonte oficial na ordem tem precedência sobre a segunda', async () => {
+    const svrs = fake([status('RS', ServiceState.Down, 'svrs')]);
+    const receita = fake([status('RS', ServiceState.Operational, 'availability')]);
+    const consensus = new ConsensusCollector([
+      { name: 'svrs', official: true, collector: svrs },
+      { name: 'availability', official: true, collector: receita },
+    ]);
+
+    const out = await consensus.collect();
+    expect(out[0]!.source).toBe('svrs');
+    expect(out[0]!.state).toBe(ServiceState.Down);
+  });
+
+  it('herda a latência real medida quando a fonte vencedora reporta 0', async () => {
+    const official = fake([status('SP', ServiceState.Operational, 'svrs', 0)]); // SVRS não mede latência
+    const third = fake([status('SP', ServiceState.Operational, 'integranotas', 250)]);
+    const consensus = new ConsensusCollector([
+      { name: 'svrs', official: true, collector: official },
+      { name: 'integranotas', official: false, collector: third },
+    ]);
+
+    const out = await consensus.collect();
+    expect(out[0]!.source).toBe('svrs'); // estado é o oficial
+    expect(out[0]!.latencyMs).toBe(250); // latência herdada da fonte que mediu
+  });
+
+  it('uma fonte que lança não derruba as demais', async () => {
+    const broken = fake([], true);
+    const ok = fake([status('SP', ServiceState.Operational, 'integranotas')]);
+    const consensus = new ConsensusCollector([
+      { name: 'svrs', official: true, collector: broken },
+      { name: 'integranotas', official: false, collector: ok },
+    ]);
+
+    const out = await consensus.collect();
+    expect(out).toHaveLength(1);
+    expect(out[0]!.source).toBe('integranotas');
+  });
+});

--- a/packages/core/test/fixtures/svrs/cte-disponibilidade.html
+++ b/packages/core/test/fixtures/svrs/cte-disponibilidade.html
@@ -1,0 +1,534 @@
+
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Portal do Conhecimento de Transporte Eletr&#244;nico</title>
+
+    <link rel="icon" href="/Content/img/favicon.ico" type="image/x-icon" />
+
+    <link rel="stylesheet" href="/Content/font-awesome/css/font-awesome.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-matriz.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-override.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/Cte.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/print.css" media="print" />
+    <link rel="stylesheet" href="/Scripts/summernote/summernote-lite.css" />
+    <link rel="stylesheet" href="/Scripts/datepicker/datepicker.min.css" />
+
+    <link rel="stylesheet" href="/Content/css/owl.carousel.css" media="all" />
+    <link rel="alternate stylesheet" href="/Content/css/contraste.css" title="contraste" media="all" />
+    <script type="text/javascript" src="/Scripts/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="/Scripts/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/Scripts/summernote/summernote-lite.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.min.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.pt-BR.js"></script>
+    <script type="text/javascript" src="/Scripts/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="/Scripts/snap.svg-min.js"></script>
+    <script>
+        function download_arquivo_estatico(sistema, tipo, nome) {
+            var iframe = document.createElement('iframe');//se o iframe não existe, cria
+            iframe.id = 'iframe-resource';
+            iframe.style.display = 'none';
+            jQuery('body').append(iframe);
+            jQuery('#iframe-resource').attr({
+                src: '/' + sistema + '/DownloadArquivoEstatico/?sistema=' + sistema + '&tipoArquivo=' + tipo + '&nomeArquivo=' + nome
+            });
+        }
+    </script>
+
+</head>
+<body id="bodyPricipal">
+
+    <header id="cabecalho" class="cabecalho">
+        <div class="container">
+            <a class="cabecalho__logo logo" href="/Cte" title="Ir para a página inicial"><h1 class="text-hide">CTe</h1></a>
+            <span class="cabecalho__titulo ">Portal do Conhecimento de Transporte Eletr&#244;nico</span>
+            <div id="menu-parent" class="cabecalho__menu-parent">
+                    <div style="margin-bottom: 2%">
+                        <i class="fa fa-lock fa-redondo"></i>
+                        <a style="color:white; cursor:pointer" href="/Soe/Login?provider=SoeOidc">Acesso Restrito SEFAZ</a>
+                    </div>
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#menuPrincipal"> <span class="sr-only">Alterna a navegação</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button>
+                <button type="button" class="navbar-toggle busca-toggle visible-xs visible-sm" data-toggle="collapse" data-target="#frmBuscaGeral"><span class="sr-only">Abrir a busca</span><span class="glyphicon glyphicon-search"></span></button>
+
+                <form id="frmBuscaGeral" method="get" action="/Cte/Busca" class="collapse" role="search">
+                    <div class="input-group">
+                        <label for="buscageralTextBox" class="sr-only">Buscar</label>
+                        <input type="text" class="form-control" placeholder="Buscar" id="buscageralTextBox" name="palavraschave" required />
+                        <span class="input-group-btn">
+                            <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span><span class="sr-only">Buscar</span> </button>
+                        </span>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <nav id="menuPrincipal" class="navbar navbar-cor navbar-default collapse" style="height: 1px;">
+        <div class="container">
+            <div class="navbar-collapse" id="menuPrincipalCollapse">
+                <a class="sr-only" id="menuInicio">Início do menu</a>
+                <div class="redes-sociais-xs visible-xs">
+
+                </div>
+                <ul class="nav navbar-nav">
+                    <li class="active"><a title="Inicial - Página inicial do site" href="index.html">Inicial</a></li>
+                    <li><a href="/Cte" title="Home">Home</a></li>
+                    <li><a href="/Cte/Sobre" title="Sobre">Sobre</a></li>
+                    <li><a href="/Cte/Avisos" title="Avisos">Avisos</a></li>
+                    <li><a href="/Cte/Noticias" title="Notícias">Notícias</a></li>
+                        <li><a href="/Cte/Servicos" title="Serviços">Serviços</a></li>
+                    <li><a href="/Cte/Documentos" title="Documentos">Documentos</a></li>
+                        <li><a href="/Cte/Legislacao" title="Legislação">Legislação</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    
+    <div class="wrapper__corpo">
+        <div class="corpo">
+            <div class="row">
+                <div class="col-sm-offset-1 col-md-8 col-md-offset-0 coluna-principal">
+                    
+
+<div class="row">
+
+    <div class="col-sm-offset-1 col-md-11 col-md-offset-0 coluna-principal">
+
+        <div class="row">
+
+            <article class="col-xs-12 artigo artigo__pagina__simples--padrao">
+                <ol class="breadcrumb">
+                    <li><a href="/Cte">Home</a></li>
+                    <li><a href="/Cte/Disponibilidade">Disponibilidade</a></li>
+                </ol>
+                <div class="artigo__ferramentas clearfix">
+                    <div class="btn-group btn-group-sm artigo__ferramentas__botoes pull-left">
+                        <a title="Clique para imprimir esta página" class="btn btn-default" href="javascript: this.print();">
+                            <i class="fa fa-print"></i> Imprimir
+                        </a>
+                    </div>
+                </div>
+                <header class="artigo__cabecalho">
+                    <h1 class="artigo__titulo">Disponibilidade dos Web Services</h1>
+                </header>
+
+                    <div class="row">
+                        <div class="col-sm-8 col-sm-offset-1">
+                                <table class="table table-hover" style="margin-left: 20px">
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Situa&#231;&#227;o V4</b>
+                    <br />
+                    <small>
+                        17:37:34 - WS com status normal (CStat: 731)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Recep&#231;&#227;o Evento V4</b>
+                    <br />
+                    <small>
+                        17:37:48 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Recep&#231;&#227;o GTVe V4</b>
+                    <br />
+                    <small>
+                        17:38:23 - WS com status normal (CStat: 244)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Recep&#231;&#227;o Simplificado V4</b>
+                    <br />
+                    <small>
+                        17:40:21 - WS com status normal (CStat: 244)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Recepcao V4</b>
+                    <br />
+                    <small>
+                        17:40:02 - WS com status normal (CStat: 244)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS RecepcaoOS V4</b>
+                    <br />
+                    <small>
+                        17:38:06 - WS com status normal (CStat: 244)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Status V4</b>
+                    <br />
+                    <small>
+                        17:37:52 - WS com status normal (CStat: 107)
+                    </small>
+                </td>
+            </tr>
+    </table>
+
+                        </div>
+                    </div>
+            </article>
+        </div>
+    </div>
+</div>
+
+                </div>
+                <div id="divColunaLateral" class="col-sm-offset-1 col-md-4 col-md-offset-0 coluna-lateral">
+                    
+
+
+<div class="coluna-lateral__corpo">
+    <div class="row">
+
+                <div class="col-xs-12">
+                    <a href="/Soe/Login?provider=OpenIdConnect&returnUrl=/Cte">
+                        <style>
+                            .rounded-button {
+                                background-color: #f5f5f5;
+                                color: #1351b4;
+                                border: none;
+                                padding: 10px 20px;
+                                font-size: 16px;
+                                cursor: pointer;
+                                border-radius: 100em;
+                                transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+                                justify-content: space-between;
+                                align-items: center;
+                                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+                            }
+
+                                .rounded-button:hover {
+                                    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.15), 0 4px 6px rgba(0, 0, 0, 0.1);
+                                    transform: translateY(-2px);
+                                }
+
+                            .imagemGovBr {
+                                padding-left: 10px;
+                                height: 30px;
+                            }
+                        </style>
+                        <div class="btn btn-xs block m-b rounded-button">
+                            Entrar com<img class="imagemGovBr" src="https://www.gov.br/++theme++padrao_govbr/img/govbr-colorido-b.png" alt="gov.br" />
+                        </div>
+                    </a>
+                </div>
+                <br />
+                <br />
+                <br />
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-gear fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Janela de Manutenção</h2>
+                        </div>
+                        <div class="panel-body">
+                            <p>
+                                As manutenções programadas do ambiente DFe são sempre efetuadas aos Domingos das 07h00 às 09h00.
+                                Pequenas manutenções sem risco de indisponibilidade (ou de baixo risco) serão programadas
+                                com até 36 horas de antecedência. Demais manutenções, serão comunicadas em tempo hábil.
+                                Ver previsão de manutenção no box abaixo.
+                            </p>
+                                <div class="bg-warning text-justify fa-border"><strong>Não há manutenção prevista para o próximo Domingo</strong></div>
+                        </div>
+                    </section>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz secretarias" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-building fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Secretarias de Fazenda</h2>
+                    </div>
+                    <div class="panel-body">
+                        <form class="form">
+                            <div class="form-group">
+                                <select id="fExemplo" class="form-control" name="fExemplo" required="" aria-required="true" onchange="javascript: window.open(this.value)">
+                                    <option value="http://www.sefaz.ac.gov.br/">Acre</option>
+                                    <option value="http://www.sefaz.al.gov.br/">Alagoas</option>
+                                    <option value="http://www.sefaz.ap.gov.br/">Amapá</option>
+                                    <option value="http://www.sefaz.am.gov.br/">Amazonas</option>
+                                    <option value="http://www.sefaz.ba.gov.br/">Bahia</option>
+                                    <option value="http://www.sefaz.ce.gov.br/">Ceará</option>
+                                    <option value="https://receita.fazenda.df.gov.br/">Distrito Federal</option>
+                                    <option value="http://www.sefaz.es.gov.br/">Espirito Santo</option>
+                                    <option value="http://www.sefaz.go.gov.br/">Goiás</option>
+                                    <option value="http://www.sefaz.ma.gov.br/">Maranhão</option>
+                                    <option value="http://www.sefaz.mt.gov.br/">Mato Grosso</option>
+                                    <option value="http://www.sefaz.ms.gov.br/">Mato Grosso do Sul</option>
+                                    <option value="http://www.fazenda.mg.gov.br/">Minas Gerais</option>
+                                    <option value="http://www.sefa.pa.gov.br/">Pará</option>
+                                    <option value="http://www.receita.pb.gov.br/">Paraíba</option>
+                                    <option value="http://www.fazenda.pr.gov.br/">Paraná</option>
+                                    <option value="http://www.sefaz.pe.gov.br/">Pernambuco</option>
+                                    <option value="http://www.sefaz.pi.gov.br/">Piauí</option>
+                                    <option value="https://atendimentodfe.fazenda.rj.gov.br/ForAtendimentoDFE/contribuinte/formulario">Rio de Janeiro</option>
+                                    <option value="http://www.set.rn.gov.br/">Rio Grande do Norte</option>
+                                    <option value="http://www.sefaz.rs.gov.br/">Rio Grande do Sul</option>
+                                    <option value="http://www.sefin.ro.gov.br/">Rondônia</option>
+                                    <option value="http://www.sefaz.rr.gov.br/">Roraima</option>
+                                    <option value="http://www.sef.sc.gov.br/">Santa Catarina</option>
+                                    <option value="http://www.fazenda.sp.gov.br/">São Paulo</option>
+                                    <option value="http://www.sefaz.se.gov.br/">Sergipe</option>
+                                    <option value="http://www.sefaz.to.gov.br/">Tocantins</option>
+                                </select>
+                            </div>
+                        </form>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div id="qtd-dfes" class="panel-heading" style="cursor:pointer" href="#" onclick="$('#modalResumoQtdDfes').modal('show');">
+                            <i class="fa fa-newspaper-o fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">DFe Autorizados na SVRS (30 dias)</h2>
+                        </div>
+
+                    </section>
+                </div>
+                <div id="modalResumoQtdDfes" class="modal fade">
+                    <!--Como chamar um arquivo svg o que é um arquivo svg-->
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <div class="titulo-modal">
+                                    <p>DFe Autorizados na SVRS (30 dias) </p>
+                                </div>
+                            </div>
+                            <div class="modal-body modal--body">
+                                
+                                <div class="form-group">
+                                    <div class="col-lg-12 area-modal-form">
+                                        
+
+                                        <div class="col-lg-12">
+                                            <label id="tipo-de-sistema">Total de DFes:</label>
+                                            <label class="numero-de-dfes" style="font-size: 25px; font-weight: 500;"></label>
+                                        </div>
+
+                                    </div>
+                                    
+<link rel="stylesheet" href="/Content/css/DfesDoBrasil.css" />
+
+
+<!-- aqui vamos colocar o html que foi gerado na index.html-->
+<div class="container svgMapContainer">
+    <svg xmlns:mapsvg="http://mapsvg.com" xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:svg="http://www.w3.org/2000/svg"
+         xmlns="http://www.w3.org/2000/svg"
+         id="svgMap"
+         viewBox="-30 -30 700 700"
+         width="100%"
+         height="100%"
+         preserveAspectRatio="xMinYMin meet">
+    </svg>
+</div>
+
+<div class="tooltip-mapa"></div>
+
+<div class="col-md-12 qtd-tabela ">
+    <table class="table">
+        <thead class="titulo-tabela">
+            <tr>
+                <th scope="col">#</th>
+                <th scope="col">UF</th>
+                <th scope="col">DFes Autorizados</th>
+                <th scope="col">Referente ao total</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">1°</th>
+                <td class="codUf26"></td>
+                <td class="qtdDfes26">0000</td>
+                <td class="porcertagemDfes26">0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">2°</th>
+                <td class="codUf25"></td>
+                <td class="qtdDfes25" >0000</td>
+                <td class="porcertagemDfes25" >0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">3°</th>
+                <td class="codUf24"></td>
+                <td class="qtdDfes24">0000</td>
+                <td class="porcertagemDfes24" >0%</td>
+
+            </tr>
+        </tbody>
+        <caption style="margin-top: 1%;">UFs que mais autorizaram DFes.</caption>
+    </table>
+</div>
+<script type="text/javascript" src="/Scripts/brasil.js"></script>
+
+<script>
+
+    ResumoSistemasDfes('Cte');
+    
+
+
+
+</script>
+
+                                </div>
+                                <div class="corpo-modal">
+
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal" onclick="fecharModal()" style="margin-top: 2%;">Fechar</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-link fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Navegação</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                                <li><a href="/Bpe" title="BPe - Portal do Bilhete de Passagem Eletrônico">Portal do BPe</a></li>
+                                                                                        <li><a href="/Mdfe" title="MDFe - Portal do Manifesto Eletrônico de Documentos Fiscais">Portal do MDFe</a></li>
+                                                            <li><a href="/Nfce" title="NFCe - Portal da Nota Fiscal do Consumidor Eletrônica">Portal da NFCe</a></li>
+                                                            <li><a href="/Nf3e" title="NF3e - Portal da Nota Fiscal da Energia Elétrica Eletrônica">Portal da NF3E</a></li>
+                                                            <li><a href="/Nfcom" title="NFCom - Portal da Nota Fiscal Fatura de Serviço de Comunicação Eletrônica">Portal da NFCom</a></li>
+                                                            <li><a href="/Nfe" title="NFe - Portal da Nota Fiscal Eletrônica">Portal da NFe</a></li>
+                                                            <li><a href="/Nff" title="NFF - Portal da Nota Fiscal Fácil">Portal da NFF</a></li>
+                                                            <li><a href="/One" title="ONE - Portal do Operador Nacional dos Estados">Portal do ONE</a></li>
+                                                            <li><a href="/Dce" title="DCE - Portal da Declaração de Conteúdo Eletrônica">Portal da DCe</a></li>
+                                                            <li><a href="/Difal" title="DIFAL - Portal da DIFAL">Portal da DIFAL</a></li>
+                                                            <li><a href="/Pes" title="PES - Portal da Plataforma de Emissão Simplificada">Portal da PES</a></li>
+                                                            <li><a href="/Cff" title="CFF - Portal da Conformidade Fácil">Portal da CFF</a></li>
+                                                            <li><a href="/Nfag" title="NFAG - Portal da Nota Fiscal da Água e Saneamento Eletrônica">Portal da NFAG</a></li>
+                                                            <li><a href="/Nfabi" title="NFABI - Portal da Nota Fiscal Eletrônica de Alienação de Bens Imóveis">Portal da NFABI</a></li>
+                                                            <li><a href="/Nfgas" title="NFGAS - Portal da Nota Fiscal Eletrônica do Gás">Portal da NFGAS</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-cloud fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Links externos</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                            <li><a href="http://www.cte.fazenda.gov.br" target="_blank" title="CTe - Conhecimento de Transporte Eletrônico">CTe</a></li>
+                            <li><a href="http://www.nfe.fazenda.gov.br" target="_blank" title="NFe - Nota Fiscal Eletrônica">NFe</a></li>
+                            <li><a href="http://nfce.encat.org" target="_blank" title="NFCe - Notal Fiscal de Consumidor Eletrônica">NFCe</a></li>
+                            <li><a href="https://www.confaz.fazenda.gov.br/" target="_blank" title="CONFAZ - Conselho Nacional de Política Fazendaria">CONFAZ</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-question fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Dúvidas frequentes</h2>
+                        </div>
+                        <div class="panel-body">
+                            <ul>
+                                <li>
+                                    <a href="/Cte/Faq" title="Perguntas Mais Frequentes">FAQ</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+    </div>
+</div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="rodape">
+    <div class="wrapper-rodape__expediente">
+        <div class="container" style="width: 60%">
+            <div class="row">
+                <div class="col-md-12">
+                    <a class="cabecalho__logo" title="Visite o site da RECEITA ESTADUAL RS" style="background-size:cover; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Receita_branco.png)" target="_blank" href="https://receita.fazenda.rs.gov.br/"></a>
+                    <a class="cabecalho__logo" title="Visite o site da PROCERGS" style="min-width:55%; float:right; background-size:auto; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Procergs.png)" target="_blank" href="https://www.procergs.rs.gov.br/"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+
+    
+    <script type="text/javascript" src="/Scripts/bootstrap.320.min.js"></script>
+    
+    <script type="text/javascript" src="/Scripts/owl.carousel.js"></script>
+    <script type="text/javascript" src="/Scripts/banner-rotativo.js"></script>
+    <script type="text/javascript" src="/Scripts/master.js"></script>
+
+    <div id="modalLogin" class="modal fade">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">Sair</span>
+                    </button>
+                    <br />
+                </div>
+                <div class="modal-body">
+                    <div id="modalBodyResult"></div>
+                </div>
+                <div class="modal-footer"></div>
+            </div>
+        </div>
+    </div>
+
+
+</body>
+</html>
+<!-- SRVPRO964 -->

--- a/packages/core/test/fixtures/svrs/mdfe-disponibilidade.html
+++ b/packages/core/test/fixtures/svrs/mdfe-disponibilidade.html
@@ -1,0 +1,513 @@
+
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Portal do Manifesto Eletr&#244;nico de Documentos Fiscais</title>
+
+    <link rel="icon" href="/Content/img/favicon.ico" type="image/x-icon" />
+
+    <link rel="stylesheet" href="/Content/font-awesome/css/font-awesome.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-matriz.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-override.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/Mdfe.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/print.css" media="print" />
+    <link rel="stylesheet" href="/Scripts/summernote/summernote-lite.css" />
+    <link rel="stylesheet" href="/Scripts/datepicker/datepicker.min.css" />
+
+    <link rel="stylesheet" href="/Content/css/owl.carousel.css" media="all" />
+    <link rel="alternate stylesheet" href="/Content/css/contraste.css" title="contraste" media="all" />
+    <script type="text/javascript" src="/Scripts/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="/Scripts/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/Scripts/summernote/summernote-lite.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.min.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.pt-BR.js"></script>
+    <script type="text/javascript" src="/Scripts/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="/Scripts/snap.svg-min.js"></script>
+    <script>
+        function download_arquivo_estatico(sistema, tipo, nome) {
+            var iframe = document.createElement('iframe');//se o iframe não existe, cria
+            iframe.id = 'iframe-resource';
+            iframe.style.display = 'none';
+            jQuery('body').append(iframe);
+            jQuery('#iframe-resource').attr({
+                src: '/' + sistema + '/DownloadArquivoEstatico/?sistema=' + sistema + '&tipoArquivo=' + tipo + '&nomeArquivo=' + nome
+            });
+        }
+    </script>
+
+</head>
+<body id="bodyPricipal">
+
+    <header id="cabecalho" class="cabecalho">
+        <div class="container">
+            <a class="cabecalho__logo logo" href="/Mdfe" title="Ir para a página inicial"><h1 class="text-hide">MDFe</h1></a>
+            <span class="cabecalho__titulo ">Portal do Manifesto Eletr&#244;nico de Documentos Fiscais</span>
+            <div id="menu-parent" class="cabecalho__menu-parent">
+                    <div style="margin-bottom: 2%">
+                        <i class="fa fa-lock fa-redondo"></i>
+                        <a style="color:white; cursor:pointer" href="/Soe/Login?provider=SoeOidc">Acesso Restrito SEFAZ</a>
+                    </div>
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#menuPrincipal"> <span class="sr-only">Alterna a navegação</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button>
+                <button type="button" class="navbar-toggle busca-toggle visible-xs visible-sm" data-toggle="collapse" data-target="#frmBuscaGeral"><span class="sr-only">Abrir a busca</span><span class="glyphicon glyphicon-search"></span></button>
+
+                <form id="frmBuscaGeral" method="get" action="/Mdfe/Busca" class="collapse" role="search">
+                    <div class="input-group">
+                        <label for="buscageralTextBox" class="sr-only">Buscar</label>
+                        <input type="text" class="form-control" placeholder="Buscar" id="buscageralTextBox" name="palavraschave" required />
+                        <span class="input-group-btn">
+                            <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span><span class="sr-only">Buscar</span> </button>
+                        </span>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <nav id="menuPrincipal" class="navbar navbar-cor navbar-default collapse" style="height: 1px;">
+        <div class="container">
+            <div class="navbar-collapse" id="menuPrincipalCollapse">
+                <a class="sr-only" id="menuInicio">Início do menu</a>
+                <div class="redes-sociais-xs visible-xs">
+
+                </div>
+                <ul class="nav navbar-nav">
+                    <li class="active"><a title="Inicial - Página inicial do site" href="index.html">Inicial</a></li>
+                    <li><a href="/Mdfe" title="Home">Home</a></li>
+                    <li><a href="/Mdfe/Sobre" title="Sobre">Sobre</a></li>
+                    <li><a href="/Mdfe/Avisos" title="Avisos">Avisos</a></li>
+                    <li><a href="/Mdfe/Noticias" title="Notícias">Notícias</a></li>
+                        <li><a href="/Mdfe/Servicos" title="Serviços">Serviços</a></li>
+                    <li><a href="/Mdfe/Documentos" title="Documentos">Documentos</a></li>
+                        <li><a href="/Mdfe/Legislacao" title="Legislação">Legislação</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    
+    <div class="wrapper__corpo">
+        <div class="corpo">
+            <div class="row">
+                <div class="col-sm-offset-1 col-md-8 col-md-offset-0 coluna-principal">
+                    
+
+<div class="row">
+
+    <div class="col-sm-offset-1 col-md-11 col-md-offset-0 coluna-principal">
+
+        <div class="row">
+
+            <article class="col-xs-12 artigo artigo__pagina__simples--padrao">
+                <ol class="breadcrumb">
+                    <li><a href="/Mdfe">Home</a></li>
+                    <li><a href="/Mdfe/Disponibilidade">Disponibilidade</a></li>
+                </ol>
+                <div class="artigo__ferramentas clearfix">
+                    <div class="btn-group btn-group-sm artigo__ferramentas__botoes pull-left">
+                        <a title="Clique para imprimir esta página" class="btn btn-default" href="javascript: this.print();">
+                            <i class="fa fa-print"></i> Imprimir
+                        </a>
+                    </div>
+                </div>
+                <header class="artigo__cabecalho">
+                    <h1 class="artigo__titulo">Disponibilidade dos Web Services</h1>
+                </header>
+
+                    <div class="row">
+                        <div class="col-sm-8 col-sm-offset-1">
+                                <table class="table table-hover" style="margin-left: 20px">
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Autorizacao Sincrono</b>
+                    <br />
+                    <small>
+                        17:38:28 - WS com status normal (CStat: 244)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Situacao</b>
+                    <br />
+                    <small>
+                        17:40:09 - WS com status normal (CStat: 239)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Eventos</b>
+                    <br />
+                    <small>
+                        17:40:11 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Status</b>
+                    <br />
+                    <small>
+                        17:38:31 - WS com status normal (CStat: 252)
+                    </small>
+                </td>
+            </tr>
+    </table>
+
+                        </div>
+                    </div>
+            </article>
+        </div>
+    </div>
+</div>
+
+                </div>
+                <div id="divColunaLateral" class="col-sm-offset-1 col-md-4 col-md-offset-0 coluna-lateral">
+                    
+
+
+<div class="coluna-lateral__corpo">
+    <div class="row">
+
+                <div class="col-xs-12">
+                    <a href="/Soe/Login?provider=OpenIdConnect&returnUrl=/Mdfe">
+                        <style>
+                            .rounded-button {
+                                background-color: #f5f5f5;
+                                color: #1351b4;
+                                border: none;
+                                padding: 10px 20px;
+                                font-size: 16px;
+                                cursor: pointer;
+                                border-radius: 100em;
+                                transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+                                justify-content: space-between;
+                                align-items: center;
+                                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+                            }
+
+                                .rounded-button:hover {
+                                    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.15), 0 4px 6px rgba(0, 0, 0, 0.1);
+                                    transform: translateY(-2px);
+                                }
+
+                            .imagemGovBr {
+                                padding-left: 10px;
+                                height: 30px;
+                            }
+                        </style>
+                        <div class="btn btn-xs block m-b rounded-button">
+                            Entrar com<img class="imagemGovBr" src="https://www.gov.br/++theme++padrao_govbr/img/govbr-colorido-b.png" alt="gov.br" />
+                        </div>
+                    </a>
+                </div>
+                <br />
+                <br />
+                <br />
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-gear fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Janela de Manutenção</h2>
+                        </div>
+                        <div class="panel-body">
+                            <p>
+                                As manutenções programadas do ambiente DFe são sempre efetuadas aos Domingos das 07h00 às 09h00.
+                                Pequenas manutenções sem risco de indisponibilidade (ou de baixo risco) serão programadas
+                                com até 36 horas de antecedência. Demais manutenções, serão comunicadas em tempo hábil.
+                                Ver previsão de manutenção no box abaixo.
+                            </p>
+                                <div class="bg-warning text-justify fa-border"><strong>Não há manutenção prevista para o próximo Domingo</strong></div>
+                        </div>
+                    </section>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz secretarias" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-building fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Secretarias de Fazenda</h2>
+                    </div>
+                    <div class="panel-body">
+                        <form class="form">
+                            <div class="form-group">
+                                <select id="fExemplo" class="form-control" name="fExemplo" required="" aria-required="true" onchange="javascript: window.open(this.value)">
+                                    <option value="http://www.sefaz.ac.gov.br/">Acre</option>
+                                    <option value="http://www.sefaz.al.gov.br/">Alagoas</option>
+                                    <option value="http://www.sefaz.ap.gov.br/">Amapá</option>
+                                    <option value="http://www.sefaz.am.gov.br/">Amazonas</option>
+                                    <option value="http://www.sefaz.ba.gov.br/">Bahia</option>
+                                    <option value="http://www.sefaz.ce.gov.br/">Ceará</option>
+                                    <option value="https://receita.fazenda.df.gov.br/">Distrito Federal</option>
+                                    <option value="http://www.sefaz.es.gov.br/">Espirito Santo</option>
+                                    <option value="http://www.sefaz.go.gov.br/">Goiás</option>
+                                    <option value="http://www.sefaz.ma.gov.br/">Maranhão</option>
+                                    <option value="http://www.sefaz.mt.gov.br/">Mato Grosso</option>
+                                    <option value="http://www.sefaz.ms.gov.br/">Mato Grosso do Sul</option>
+                                    <option value="http://www.fazenda.mg.gov.br/">Minas Gerais</option>
+                                    <option value="http://www.sefa.pa.gov.br/">Pará</option>
+                                    <option value="http://www.receita.pb.gov.br/">Paraíba</option>
+                                    <option value="http://www.fazenda.pr.gov.br/">Paraná</option>
+                                    <option value="http://www.sefaz.pe.gov.br/">Pernambuco</option>
+                                    <option value="http://www.sefaz.pi.gov.br/">Piauí</option>
+                                    <option value="https://atendimentodfe.fazenda.rj.gov.br/ForAtendimentoDFE/contribuinte/formulario">Rio de Janeiro</option>
+                                    <option value="http://www.set.rn.gov.br/">Rio Grande do Norte</option>
+                                    <option value="http://www.sefaz.rs.gov.br/">Rio Grande do Sul</option>
+                                    <option value="http://www.sefin.ro.gov.br/">Rondônia</option>
+                                    <option value="http://www.sefaz.rr.gov.br/">Roraima</option>
+                                    <option value="http://www.sef.sc.gov.br/">Santa Catarina</option>
+                                    <option value="http://www.fazenda.sp.gov.br/">São Paulo</option>
+                                    <option value="http://www.sefaz.se.gov.br/">Sergipe</option>
+                                    <option value="http://www.sefaz.to.gov.br/">Tocantins</option>
+                                </select>
+                            </div>
+                        </form>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div id="qtd-dfes" class="panel-heading" style="cursor:pointer" href="#" onclick="$('#modalResumoQtdDfes').modal('show');">
+                            <i class="fa fa-newspaper-o fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">DFe Autorizados na SVRS (30 dias)</h2>
+                        </div>
+
+                    </section>
+                </div>
+                <div id="modalResumoQtdDfes" class="modal fade">
+                    <!--Como chamar um arquivo svg o que é um arquivo svg-->
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <div class="titulo-modal">
+                                    <p>DFe Autorizados na SVRS (30 dias) </p>
+                                </div>
+                            </div>
+                            <div class="modal-body modal--body">
+                                
+                                <div class="form-group">
+                                    <div class="col-lg-12 area-modal-form">
+                                        
+
+                                        <div class="col-lg-12">
+                                            <label id="tipo-de-sistema">Total de DFes:</label>
+                                            <label class="numero-de-dfes" style="font-size: 25px; font-weight: 500;"></label>
+                                        </div>
+
+                                    </div>
+                                    
+<link rel="stylesheet" href="/Content/css/DfesDoBrasil.css" />
+
+
+<!-- aqui vamos colocar o html que foi gerado na index.html-->
+<div class="container svgMapContainer">
+    <svg xmlns:mapsvg="http://mapsvg.com" xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:svg="http://www.w3.org/2000/svg"
+         xmlns="http://www.w3.org/2000/svg"
+         id="svgMap"
+         viewBox="-30 -30 700 700"
+         width="100%"
+         height="100%"
+         preserveAspectRatio="xMinYMin meet">
+    </svg>
+</div>
+
+<div class="tooltip-mapa"></div>
+
+<div class="col-md-12 qtd-tabela ">
+    <table class="table">
+        <thead class="titulo-tabela">
+            <tr>
+                <th scope="col">#</th>
+                <th scope="col">UF</th>
+                <th scope="col">DFes Autorizados</th>
+                <th scope="col">Referente ao total</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">1°</th>
+                <td class="codUf26"></td>
+                <td class="qtdDfes26">0000</td>
+                <td class="porcertagemDfes26">0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">2°</th>
+                <td class="codUf25"></td>
+                <td class="qtdDfes25" >0000</td>
+                <td class="porcertagemDfes25" >0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">3°</th>
+                <td class="codUf24"></td>
+                <td class="qtdDfes24">0000</td>
+                <td class="porcertagemDfes24" >0%</td>
+
+            </tr>
+        </tbody>
+        <caption style="margin-top: 1%;">UFs que mais autorizaram DFes.</caption>
+    </table>
+</div>
+<script type="text/javascript" src="/Scripts/brasil.js"></script>
+
+<script>
+
+    ResumoSistemasDfes('Mdfe');
+    
+
+
+
+</script>
+
+                                </div>
+                                <div class="corpo-modal">
+
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal" onclick="fecharModal()" style="margin-top: 2%;">Fechar</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-link fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Navegação</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                                <li><a href="/Bpe" title="BPe - Portal do Bilhete de Passagem Eletrônico">Portal do BPe</a></li>
+                                                            <li><a href="/Cte" title="CTe - Portal do Conhecimento de Transporte Eletrônico">Portal do CTe</a></li>
+                                                                                        <li><a href="/Nfce" title="NFCe - Portal da Nota Fiscal do Consumidor Eletrônica">Portal da NFCe</a></li>
+                                                            <li><a href="/Nf3e" title="NF3e - Portal da Nota Fiscal da Energia Elétrica Eletrônica">Portal da NF3E</a></li>
+                                                            <li><a href="/Nfcom" title="NFCom - Portal da Nota Fiscal Fatura de Serviço de Comunicação Eletrônica">Portal da NFCom</a></li>
+                                                            <li><a href="/Nfe" title="NFe - Portal da Nota Fiscal Eletrônica">Portal da NFe</a></li>
+                                                            <li><a href="/Nff" title="NFF - Portal da Nota Fiscal Fácil">Portal da NFF</a></li>
+                                                            <li><a href="/One" title="ONE - Portal do Operador Nacional dos Estados">Portal do ONE</a></li>
+                                                            <li><a href="/Dce" title="DCE - Portal da Declaração de Conteúdo Eletrônica">Portal da DCe</a></li>
+                                                            <li><a href="/Difal" title="DIFAL - Portal da DIFAL">Portal da DIFAL</a></li>
+                                                            <li><a href="/Pes" title="PES - Portal da Plataforma de Emissão Simplificada">Portal da PES</a></li>
+                                                            <li><a href="/Cff" title="CFF - Portal da Conformidade Fácil">Portal da CFF</a></li>
+                                                            <li><a href="/Nfag" title="NFAG - Portal da Nota Fiscal da Água e Saneamento Eletrônica">Portal da NFAG</a></li>
+                                                            <li><a href="/Nfabi" title="NFABI - Portal da Nota Fiscal Eletrônica de Alienação de Bens Imóveis">Portal da NFABI</a></li>
+                                                            <li><a href="/Nfgas" title="NFGAS - Portal da Nota Fiscal Eletrônica do Gás">Portal da NFGAS</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-cloud fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Links externos</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                            <li><a href="http://www.cte.fazenda.gov.br" target="_blank" title="CTe - Conhecimento de Transporte Eletrônico">CTe</a></li>
+                            <li><a href="http://www.nfe.fazenda.gov.br" target="_blank" title="NFe - Nota Fiscal Eletrônica">NFe</a></li>
+                            <li><a href="http://nfce.encat.org" target="_blank" title="NFCe - Notal Fiscal de Consumidor Eletrônica">NFCe</a></li>
+                            <li><a href="https://www.confaz.fazenda.gov.br/" target="_blank" title="CONFAZ - Conselho Nacional de Política Fazendaria">CONFAZ</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-question fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Dúvidas frequentes</h2>
+                        </div>
+                        <div class="panel-body">
+                            <ul>
+                                <li>
+                                    <a href="/Mdfe/Faq" title="Perguntas Mais Frequentes">FAQ</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                        </div>
+                        <div class="panel-body">
+                            <ul style="list-style-type:none">
+                                <li>
+                                    <a href="#" onclick="download_arquivo_estatico('Mdfe', 0, 'Cartilha_mdfe_nacional_agosto_2016.pdf');">
+                                        <img src="/Content/img/ban_cartilhanacional.png" width="200" height="191" border="0" alt="Cartilha Nacional do MDFe" title="Cartilha Nacional do MDFe">
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+    </div>
+</div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="rodape">
+    <div class="wrapper-rodape__expediente">
+        <div class="container" style="width: 60%">
+            <div class="row">
+                <div class="col-md-12">
+                    <a class="cabecalho__logo" title="Visite o site da RECEITA ESTADUAL RS" style="background-size:cover; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Receita_branco.png)" target="_blank" href="https://receita.fazenda.rs.gov.br/"></a>
+                    <a class="cabecalho__logo" title="Visite o site da PROCERGS" style="min-width:55%; float:right; background-size:auto; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Procergs.png)" target="_blank" href="https://www.procergs.rs.gov.br/"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+
+    
+    <script type="text/javascript" src="/Scripts/bootstrap.320.min.js"></script>
+    
+    <script type="text/javascript" src="/Scripts/owl.carousel.js"></script>
+    <script type="text/javascript" src="/Scripts/banner-rotativo.js"></script>
+    <script type="text/javascript" src="/Scripts/master.js"></script>
+
+    <div id="modalLogin" class="modal fade">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">Sair</span>
+                    </button>
+                    <br />
+                </div>
+                <div class="modal-body">
+                    <div id="modalBodyResult"></div>
+                </div>
+                <div class="modal-footer"></div>
+            </div>
+        </div>
+    </div>
+
+
+</body>
+</html>
+<!-- SRVPRO964 -->

--- a/packages/core/test/fixtures/svrs/nfe-disponibilidade.html
+++ b/packages/core/test/fixtures/svrs/nfe-disponibilidade.html
@@ -1,0 +1,641 @@
+
+<!DOCTYPE html>
+<html lang="pt">
+<head>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <title>Portal da Nota Fiscal Eletr&#244;nica - SVRS</title>
+
+    <link rel="icon" href="/Content/img/favicon.ico" type="image/x-icon" />
+
+    <link rel="stylesheet" href="/Content/font-awesome/css/font-awesome.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-matriz.min.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/bootstrap-override.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/Nfe.css" media="all" />
+    <link rel="stylesheet" href="/Content/css/print.css" media="print" />
+    <link rel="stylesheet" href="/Scripts/summernote/summernote-lite.css" />
+    <link rel="stylesheet" href="/Scripts/datepicker/datepicker.min.css" />
+
+    <link rel="stylesheet" href="/Content/css/owl.carousel.css" media="all" />
+    <link rel="alternate stylesheet" href="/Content/css/contraste.css" title="contraste" media="all" />
+    <script type="text/javascript" src="/Scripts/jquery-3.2.1.min.js"></script>
+    <script type="text/javascript" src="/Scripts/bootstrap.min.js"></script>
+    <script type="text/javascript" src="/Scripts/summernote/summernote-lite.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.min.js"></script>
+    <script type="text/javascript" src="/Scripts/datepicker/datepicker.pt-BR.js"></script>
+    <script type="text/javascript" src="/Scripts/jquery.browser.min.js"></script>
+    <script type="text/javascript" src="/Scripts/snap.svg-min.js"></script>
+    <script>
+        function download_arquivo_estatico(sistema, tipo, nome) {
+            var iframe = document.createElement('iframe');//se o iframe não existe, cria
+            iframe.id = 'iframe-resource';
+            iframe.style.display = 'none';
+            jQuery('body').append(iframe);
+            jQuery('#iframe-resource').attr({
+                src: '/' + sistema + '/DownloadArquivoEstatico/?sistema=' + sistema + '&tipoArquivo=' + tipo + '&nomeArquivo=' + nome
+            });
+        }
+    </script>
+
+</head>
+<body id="bodyPricipal">
+
+    <header id="cabecalho" class="cabecalho">
+        <div class="container">
+            <a class="cabecalho__logo logo" href="/Nfe" title="Ir para a página inicial"><h1 class="text-hide">NFe</h1></a>
+            <span class="cabecalho__titulo ">Portal da Nota Fiscal Eletr&#244;nica - SVRS</span>
+            <div id="menu-parent" class="cabecalho__menu-parent">
+                    <div style="margin-bottom: 2%">
+                        <i class="fa fa-lock fa-redondo"></i>
+                        <a style="color:white; cursor:pointer" href="/Soe/Login?provider=SoeOidc">Acesso Restrito SEFAZ</a>
+                    </div>
+                <button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#menuPrincipal"> <span class="sr-only">Alterna a navegação</span> <span class="icon-bar"></span> <span class="icon-bar"></span> <span class="icon-bar"></span></button>
+                <button type="button" class="navbar-toggle busca-toggle visible-xs visible-sm" data-toggle="collapse" data-target="#frmBuscaGeral"><span class="sr-only">Abrir a busca</span><span class="glyphicon glyphicon-search"></span></button>
+
+                <form id="frmBuscaGeral" method="get" action="/Nfe/Busca" class="collapse" role="search">
+                    <div class="input-group">
+                        <label for="buscageralTextBox" class="sr-only">Buscar</label>
+                        <input type="text" class="form-control" placeholder="Buscar" id="buscageralTextBox" name="palavraschave" required />
+                        <span class="input-group-btn">
+                            <button type="submit" class="btn btn-default"><span class="glyphicon glyphicon-search"></span><span class="sr-only">Buscar</span> </button>
+                        </span>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </header>
+
+    <nav id="menuPrincipal" class="navbar navbar-cor navbar-default collapse" style="height: 1px;">
+        <div class="container">
+            <div class="navbar-collapse" id="menuPrincipalCollapse">
+                <a class="sr-only" id="menuInicio">Início do menu</a>
+                <div class="redes-sociais-xs visible-xs">
+
+                </div>
+                <ul class="nav navbar-nav">
+                    <li class="active"><a title="Inicial - Página inicial do site" href="index.html">Inicial</a></li>
+                    <li><a href="/Nfe" title="Home">Home</a></li>
+                    <li><a href="/Nfe/Sobre" title="Sobre">Sobre</a></li>
+                    <li><a href="/Nfe/Avisos" title="Avisos">Avisos</a></li>
+                    <li><a href="/Nfe/Noticias" title="Notícias">Notícias</a></li>
+                        <li><a href="/Nfe/Servicos" title="Serviços">Serviços</a></li>
+                    <li><a href="/Nfe/Documentos" title="Documentos">Documentos</a></li>
+                        <li><a href="/Nfe/Legislacao" title="Legislação">Legislação</a></li>
+                </ul>
+            </div>
+        </div>
+    </nav>
+
+    
+    <div class="wrapper__corpo">
+        <div class="corpo">
+            <div class="row">
+                <div class="col-sm-offset-1 col-md-8 col-md-offset-0 coluna-principal">
+                    
+
+<div class="row">
+
+    <div class="col-sm-offset-1 col-md-11 col-md-offset-0 coluna-principal">
+
+        <div class="row">
+
+            <article class="col-xs-12 artigo artigo__pagina__simples--padrao">
+                <ol class="breadcrumb">
+                    <li><a href="/Nfe">Home</a></li>
+                    <li><a href="/Nfe/Disponibilidade">Disponibilidade</a></li>
+                </ol>
+                <div class="artigo__ferramentas clearfix">
+                    <div class="btn-group btn-group-sm artigo__ferramentas__botoes pull-left">
+                        <a title="Clique para imprimir esta página" class="btn btn-default" href="javascript: this.print();">
+                            <i class="fa fa-print"></i> Imprimir
+                        </a>
+                    </div>
+                </div>
+                <header class="artigo__cabecalho">
+                    <h1 class="artigo__titulo">Disponibilidade dos Web Services</h1>
+                </header>
+
+                    <div class="row">
+                        <div class="col-sm-6">
+                            <div class="col-sm-11 col-sm-offset-1">
+                                <h4>SEFAZ-RS</h4>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12 no-margins no-borders no-padding">
+                                        <table class="table table-hover" style="margin-left: 20px">
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Autorizacao (URL)</b>
+                    <br />
+                    <small>
+                        17:38:57 - WS com status normal (CStat: 225)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Recibo (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 106)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Situacao (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 526)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Evento (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Inutilizacao (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Status (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 107)
+                    </small>
+                </td>
+            </tr>
+    </table>
+
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-sm-6">
+
+                            <div class="col-sm-11 col-sm-offset-1 order-3">
+                                <h4>SEFAZ Virtual do RS</h4>
+                            </div>
+                            <div class="row">
+                                <div class="col-sm-12 no-margins no-borders no-padding">
+                                        <table class="table table-hover" style="margin-left: 20px">
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Autorizacao (URL)</b>
+                    <br />
+                    <small>
+                        17:38:52 - WS com status normal (CStat: 225)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Cadastro(URL)</b>
+                    <br />
+                    <small>
+                        03:30:37 - Erro ao executar a Monitoria [SVP] WebServices-WS Consulta Cadastro(URL). - Erro ao tentar acessar Web Service.
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Recibo (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 410)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Consulta Situacao (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 410)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Evento (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Inutilizacao (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 215)
+                    </small>
+                </td>
+            </tr>
+            <tr>
+                <td style="width: 30px;vertical-align:middle; ">
+                    <i class="fa fa-lg fa-check-circle" style="color: #3c763d "></i>
+                </td>
+                <td style="">
+                    <b>WS Status (URL)</b>
+                    <br />
+                    <small>
+                        17:39:53 - WS com status normal (CStat: 410)
+                    </small>
+                </td>
+            </tr>
+    </table>
+
+                                </div>
+                            </div>                          
+                        </div>
+                    </div>
+            </article>
+        </div>
+    </div>
+</div>
+
+                </div>
+                <div id="divColunaLateral" class="col-sm-offset-1 col-md-4 col-md-offset-0 coluna-lateral">
+                    
+
+
+<div class="coluna-lateral__corpo">
+    <div class="row">
+
+                <div class="col-xs-12">
+                    <a href="/Soe/Login?provider=OpenIdConnect&returnUrl=/Nfe">
+                        <style>
+                            .rounded-button {
+                                background-color: #f5f5f5;
+                                color: #1351b4;
+                                border: none;
+                                padding: 10px 20px;
+                                font-size: 16px;
+                                cursor: pointer;
+                                border-radius: 100em;
+                                transition: background-color 0.3s ease, transform 0.2s ease, box-shadow 0.3s ease;
+                                justify-content: space-between;
+                                align-items: center;
+                                box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1), 0 2px 4px rgba(0, 0, 0, 0.06);
+                            }
+
+                                .rounded-button:hover {
+                                    box-shadow: 0 10px 15px rgba(0, 0, 0, 0.15), 0 4px 6px rgba(0, 0, 0, 0.1);
+                                    transform: translateY(-2px);
+                                }
+
+                            .imagemGovBr {
+                                padding-left: 10px;
+                                height: 30px;
+                            }
+                        </style>
+                        <div class="btn btn-xs block m-b rounded-button">
+                            Entrar com<img class="imagemGovBr" src="https://www.gov.br/++theme++padrao_govbr/img/govbr-colorido-b.png" alt="gov.br" />
+                        </div>
+                    </a>
+                </div>
+                <br />
+                <br />
+                <br />
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-gear fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Janela de Manutenção</h2>
+                        </div>
+                        <div class="panel-body">
+                            <p>
+                                As manutenções programadas do ambiente DFe são sempre efetuadas aos Domingos das 07h00 às 09h00.
+                                Pequenas manutenções sem risco de indisponibilidade (ou de baixo risco) serão programadas
+                                com até 36 horas de antecedência. Demais manutenções, serão comunicadas em tempo hábil.
+                                Ver previsão de manutenção no box abaixo.
+                            </p>
+                                <div class="bg-warning text-justify fa-border"><strong>Não há manutenção prevista para o próximo Domingo</strong></div>
+                        </div>
+                    </section>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz secretarias" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-building fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Secretarias de Fazenda</h2>
+                    </div>
+                    <div class="panel-body">
+                        <form class="form">
+                            <div class="form-group">
+                                <select id="fExemplo" class="form-control" name="fExemplo" required="" aria-required="true" onchange="javascript: window.open(this.value)">
+                                    <option value="http://www.sefaz.ac.gov.br/">Acre</option>
+                                    <option value="http://www.sefaz.al.gov.br/">Alagoas</option>
+                                    <option value="http://www.sefaz.ap.gov.br/">Amapá</option>
+                                    <option value="http://www.sefaz.am.gov.br/">Amazonas</option>
+                                    <option value="http://www.sefaz.ba.gov.br/">Bahia</option>
+                                    <option value="http://www.sefaz.ce.gov.br/">Ceará</option>
+                                    <option value="https://receita.fazenda.df.gov.br/">Distrito Federal</option>
+                                    <option value="http://www.sefaz.es.gov.br/">Espirito Santo</option>
+                                    <option value="http://www.sefaz.go.gov.br/">Goiás</option>
+                                    <option value="http://www.sefaz.ma.gov.br/">Maranhão</option>
+                                    <option value="http://www.sefaz.mt.gov.br/">Mato Grosso</option>
+                                    <option value="http://www.sefaz.ms.gov.br/">Mato Grosso do Sul</option>
+                                    <option value="http://www.fazenda.mg.gov.br/">Minas Gerais</option>
+                                    <option value="http://www.sefa.pa.gov.br/">Pará</option>
+                                    <option value="http://www.receita.pb.gov.br/">Paraíba</option>
+                                    <option value="http://www.fazenda.pr.gov.br/">Paraná</option>
+                                    <option value="http://www.sefaz.pe.gov.br/">Pernambuco</option>
+                                    <option value="http://www.sefaz.pi.gov.br/">Piauí</option>
+                                    <option value="https://atendimentodfe.fazenda.rj.gov.br/ForAtendimentoDFE/contribuinte/formulario">Rio de Janeiro</option>
+                                    <option value="http://www.set.rn.gov.br/">Rio Grande do Norte</option>
+                                    <option value="http://www.sefaz.rs.gov.br/">Rio Grande do Sul</option>
+                                    <option value="http://www.sefin.ro.gov.br/">Rondônia</option>
+                                    <option value="http://www.sefaz.rr.gov.br/">Roraima</option>
+                                    <option value="http://www.sef.sc.gov.br/">Santa Catarina</option>
+                                    <option value="http://www.fazenda.sp.gov.br/">São Paulo</option>
+                                    <option value="http://www.sefaz.se.gov.br/">Sergipe</option>
+                                    <option value="http://www.sefaz.to.gov.br/">Tocantins</option>
+                                </select>
+                            </div>
+                        </form>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div id="qtd-dfes" class="panel-heading" style="cursor:pointer" href="#" onclick="$('#modalResumoQtdDfes').modal('show');">
+                            <i class="fa fa-newspaper-o fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">DFe Autorizados na SVRS (30 dias)</h2>
+                        </div>
+
+                    </section>
+                </div>
+                <div id="modalResumoQtdDfes" class="modal fade">
+                    <!--Como chamar um arquivo svg o que é um arquivo svg-->
+                    <div class="modal-dialog" role="document">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <div class="titulo-modal">
+                                    <p>DFe Autorizados na SVRS (30 dias) </p>
+                                </div>
+                            </div>
+                            <div class="modal-body modal--body">
+                                
+                                <div class="form-group">
+                                    <div class="col-lg-12 area-modal-form">
+                                        
+
+                                        <div class="col-lg-12">
+                                            <label id="tipo-de-sistema">Total de DFes:</label>
+                                            <label class="numero-de-dfes" style="font-size: 25px; font-weight: 500;"></label>
+                                        </div>
+
+                                    </div>
+                                    
+<link rel="stylesheet" href="/Content/css/DfesDoBrasil.css" />
+
+
+<!-- aqui vamos colocar o html que foi gerado na index.html-->
+<div class="container svgMapContainer">
+    <svg xmlns:mapsvg="http://mapsvg.com" xmlns:dc="http://purl.org/dc/elements/1.1/"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:svg="http://www.w3.org/2000/svg"
+         xmlns="http://www.w3.org/2000/svg"
+         id="svgMap"
+         viewBox="-30 -30 700 700"
+         width="100%"
+         height="100%"
+         preserveAspectRatio="xMinYMin meet">
+    </svg>
+</div>
+
+<div class="tooltip-mapa"></div>
+
+<div class="col-md-12 qtd-tabela ">
+    <table class="table">
+        <thead class="titulo-tabela">
+            <tr>
+                <th scope="col">#</th>
+                <th scope="col">UF</th>
+                <th scope="col">DFes Autorizados</th>
+                <th scope="col">Referente ao total</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <th scope="row">1°</th>
+                <td class="codUf26"></td>
+                <td class="qtdDfes26">0000</td>
+                <td class="porcertagemDfes26">0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">2°</th>
+                <td class="codUf25"></td>
+                <td class="qtdDfes25" >0000</td>
+                <td class="porcertagemDfes25" >0%</td>
+
+            </tr>
+            <tr>
+                <th scope="row">3°</th>
+                <td class="codUf24"></td>
+                <td class="qtdDfes24">0000</td>
+                <td class="porcertagemDfes24" >0%</td>
+
+            </tr>
+        </tbody>
+        <caption style="margin-top: 1%;">UFs que mais autorizaram DFes.</caption>
+    </table>
+</div>
+<script type="text/javascript" src="/Scripts/brasil.js"></script>
+
+<script>
+
+    ResumoSistemasDfes('Nfe');
+    
+
+
+
+</script>
+
+                                </div>
+                                <div class="corpo-modal">
+
+                                </div>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal" onclick="fecharModal()" style="margin-top: 2%;">Fechar</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-link fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Navegação</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                                <li><a href="/Bpe" title="BPe - Portal do Bilhete de Passagem Eletrônico">Portal do BPe</a></li>
+                                                            <li><a href="/Cte" title="CTe - Portal do Conhecimento de Transporte Eletrônico">Portal do CTe</a></li>
+                                                            <li><a href="/Mdfe" title="MDFe - Portal do Manifesto Eletrônico de Documentos Fiscais">Portal do MDFe</a></li>
+                                                            <li><a href="/Nfce" title="NFCe - Portal da Nota Fiscal do Consumidor Eletrônica">Portal da NFCe</a></li>
+                                                            <li><a href="/Nf3e" title="NF3e - Portal da Nota Fiscal da Energia Elétrica Eletrônica">Portal da NF3E</a></li>
+                                                            <li><a href="/Nfcom" title="NFCom - Portal da Nota Fiscal Fatura de Serviço de Comunicação Eletrônica">Portal da NFCom</a></li>
+                                                                                        <li><a href="/Nff" title="NFF - Portal da Nota Fiscal Fácil">Portal da NFF</a></li>
+                                                            <li><a href="/One" title="ONE - Portal do Operador Nacional dos Estados">Portal do ONE</a></li>
+                                                            <li><a href="/Dce" title="DCE - Portal da Declaração de Conteúdo Eletrônica">Portal da DCe</a></li>
+                                                            <li><a href="/Difal" title="DIFAL - Portal da DIFAL">Portal da DIFAL</a></li>
+                                                            <li><a href="/Pes" title="PES - Portal da Plataforma de Emissão Simplificada">Portal da PES</a></li>
+                                                            <li><a href="/Cff" title="CFF - Portal da Conformidade Fácil">Portal da CFF</a></li>
+                                                            <li><a href="/Nfag" title="NFAG - Portal da Nota Fiscal da Água e Saneamento Eletrônica">Portal da NFAG</a></li>
+                                                            <li><a href="/Nfabi" title="NFABI - Portal da Nota Fiscal Eletrônica de Alienação de Bens Imóveis">Portal da NFABI</a></li>
+                                                            <li><a href="/Nfgas" title="NFGAS - Portal da Nota Fiscal Eletrônica do Gás">Portal da NFGAS</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+            <div class="col-xs-12">
+                <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                    <div class="panel-heading">
+                        <i class="fa fa-cloud fa-redondo" style="margin-right:8px"></i>
+                        <h2 class="panel-title">Links externos</h2>
+                    </div>
+                    <div class="panel-body">
+                        <ul style="font-size: 110%">
+                            <li><a href="http://www.cte.fazenda.gov.br" target="_blank" title="CTe - Conhecimento de Transporte Eletrônico">CTe</a></li>
+                            <li><a href="http://www.nfe.fazenda.gov.br" target="_blank" title="NFe - Nota Fiscal Eletrônica">NFe</a></li>
+                            <li><a href="http://nfce.encat.org" target="_blank" title="NFCe - Notal Fiscal de Consumidor Eletrônica">NFCe</a></li>
+                            <li><a href="https://www.confaz.fazenda.gov.br/" target="_blank" title="CONFAZ - Conselho Nacional de Política Fazendaria">CONFAZ</a></li>
+                        </ul>
+                    </div>
+                </section>
+            </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                            <i class="fa fa-question fa-redondo" style="margin-right:8px"></i>
+                            <h2 class="panel-title">Dúvidas frequentes</h2>
+                        </div>
+                        <div class="panel-body">
+                            <ul>
+                                <li>
+                                    <a href="/Nfe/Faq" title="Perguntas Mais Frequentes">FAQ</a>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+                <div class="col-xs-12">
+                    <section class="panel panel-default panel--matriz lista-links" style="margin-bottom: 4%">
+                        <div class="panel-heading">
+                        </div>
+                        <div class="panel-body">
+                            <ul style="list-style-type:none">
+                                <li>
+                                    <a href="https://www.placsvba.ba.gov.br/">
+                                        <img src="/Content/img/banner-placa-Fate.png" width="200" height="131" border="0" alt="Plac FATe" title="Plac FATe">
+                                    </a>
+                                </li>
+                            </ul>
+                        </div>
+                    </section>
+                </div>
+    </div>
+</div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <footer class="rodape">
+    <div class="wrapper-rodape__expediente">
+        <div class="container" style="width: 60%">
+            <div class="row">
+                <div class="col-md-12">
+                    <a class="cabecalho__logo" title="Visite o site da RECEITA ESTADUAL RS" style="background-size:cover; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Receita_branco.png)" target="_blank" href="https://receita.fazenda.rs.gov.br/"></a>
+                    <a class="cabecalho__logo" title="Visite o site da PROCERGS" style="min-width:55%; float:right; background-size:auto; background-position: 50% 50%; background-image:url(../../Content/img/logos/logo_Procergs.png)" target="_blank" href="https://www.procergs.rs.gov.br/"></a>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
+
+    
+    <script type="text/javascript" src="/Scripts/bootstrap.320.min.js"></script>
+    
+    <script type="text/javascript" src="/Scripts/owl.carousel.js"></script>
+    <script type="text/javascript" src="/Scripts/banner-rotativo.js"></script>
+    <script type="text/javascript" src="/Scripts/master.js"></script>
+
+    <div id="modalLogin" class="modal fade">
+        <div class="modal-dialog" role="document">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                        <span aria-hidden="true">Sair</span>
+                    </button>
+                    <br />
+                </div>
+                <div class="modal-body">
+                    <div id="modalBodyResult"></div>
+                </div>
+                <div class="modal-footer"></div>
+            </div>
+        </div>
+    </div>
+
+
+</body>
+</html>
+<!-- SRVPRO964 -->

--- a/packages/core/test/svrs/SvrsCollector.test.ts
+++ b/packages/core/test/svrs/SvrsCollector.test.ts
@@ -1,0 +1,42 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { DocumentType } from '@monitor-sefaz/catalog';
+import { SvrsCollector } from '../../src/svrs/SvrsCollector.js';
+import { SvrsProvider, type SvrsFetcher } from '../../src/svrs/SvrsProvider.js';
+import { ServiceState } from '../../src/domain/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string): string =>
+  readFileSync(resolve(here, '../fixtures/svrs', name), 'latin1');
+
+/** Fetcher que serve a fixture do documento pedido pela URL. */
+const fixtureFetcher: SvrsFetcher = async (url) => {
+  if (url.includes('/Nfe/')) return fixture('nfe-disponibilidade.html');
+  if (url.includes('/Cte/')) return fixture('cte-disponibilidade.html');
+  if (url.includes('/Mdfe/')) return fixture('mdfe-disponibilidade.html');
+  throw new Error(`URL inesperada: ${url}`);
+};
+
+describe('SvrsCollector', () => {
+  it('expande o status do SVRS por UF, com cStat real e source "svrs"', async () => {
+    const collector = new SvrsCollector(new SvrsProvider(fixtureFetcher));
+    const out = await collector.collect();
+
+    expect(out.length).toBeGreaterThan(0);
+    for (const s of out) {
+      expect(s.source).toBe('svrs');
+    }
+
+    // O RS de NF-e vem da seção SEFAZ-RS; deve estar presente e operacional no snapshot.
+    const rsNfe = out.find((s) => s.uf === 'RS' && s.document === DocumentType.NFe);
+    expect(rsNfe).toBeDefined();
+    expect(rsNfe!.state).toBe(ServiceState.Operational);
+    expect(rsNfe!.cStat).not.toBeNull();
+
+    // MDF-e é nacional no SVRS: deve cobrir várias UFs.
+    const mdfe = out.filter((s) => s.document === DocumentType.MDFe);
+    expect(mdfe.length).toBeGreaterThan(1);
+  });
+});

--- a/packages/core/test/svrs/SvrsCollector.test.ts
+++ b/packages/core/test/svrs/SvrsCollector.test.ts
@@ -39,4 +39,14 @@ describe('SvrsCollector', () => {
     const mdfe = out.filter((s) => s.document === DocumentType.MDFe);
     expect(mdfe.length).toBeGreaterThan(1);
   });
+
+  it('propaga o horário de aferição do SVRS em sourceCheckedAt', async () => {
+    const collector = new SvrsCollector(new SvrsProvider(fixtureFetcher));
+    const out = await collector.collect();
+    const withTime = out.filter((s) => s.sourceCheckedAt);
+    expect(withTime.length).toBeGreaterThan(0);
+    for (const s of withTime) {
+      expect(s.sourceCheckedAt).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    }
+  });
 });

--- a/packages/core/test/svrs/SvrsParser.test.ts
+++ b/packages/core/test/svrs/SvrsParser.test.ts
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SvrsParser } from '../../src/svrs/SvrsParser.js';
+import { ServiceState } from '../../src/domain/types.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = (name: string): string =>
+  readFileSync(resolve(here, '../fixtures/svrs', name), 'latin1');
+
+describe('SvrsParser', () => {
+  it('extrai SEFAZ-RS e SVRS da página de NF-e (duas seções)', () => {
+    const rows = new SvrsParser().parse(fixture('nfe-disponibilidade.html'));
+    const authorizers = rows.map((r) => r.authorizer).sort();
+    expect(authorizers).toEqual(['SEFAZ-RS', 'SVRS']);
+
+    for (const row of rows) {
+      expect(row.webServices.length).toBeGreaterThan(0);
+      // O snapshot foi capturado com os serviços normais (cStat 1xx/2xx/5xx).
+      expect(row.state).toBe(ServiceState.Operational);
+      expect(row.cStat).not.toBeNull();
+      expect(row.lastCheckTime).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+    }
+  });
+
+  it('extrai o autorizador único da página de CT-e (sem <h4>)', () => {
+    const rows = new SvrsParser().parse(fixture('cte-disponibilidade.html'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.authorizer).toBe('SVRS');
+    expect(rows[0]!.webServices.length).toBeGreaterThan(0);
+    expect(rows[0]!.cStat).not.toBeNull();
+  });
+
+  it('extrai o autorizador único da página de MDF-e', () => {
+    const rows = new SvrsParser().parse(fixture('mdfe-disponibilidade.html'));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.authorizer).toBe('SVRS');
+    expect(rows[0]!.webServices.length).toBeGreaterThan(0);
+  });
+
+  it('devolve [] para HTML sem tabela de webservices', () => {
+    expect(new SvrsParser().parse('<html><body>nada</body></html>')).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Objetivo

Ampliar as fontes de dados do monitor e sair da dependência de um único terceiro, cruzando fontes públicas (sem certificado A1) por **consenso com precedência oficial**.

## O que muda

### Fase 1 — Consenso multi-fonte

- **Nova fonte SVRS** (`packages/core/src/svrs/`): raspa o portal oficial `dfe-portal.svrs.rs.gov.br`, que entrega `cStat` real e horário de aferição por webservice. Parser + Provider + Collector, com o fetcher axios isolado em `svrs/httpFetcher.ts` para o bundle do Worker não puxar axios/tough-cookie.
- **`ConsensusCollector`**: substitui o failover do `HybridCollector` por um cruzamento real — coleta todas as fontes em paralelo (`allSettled`) e, por `document:uf`, a primeira fonte **oficial** (SVRS → página da Receita) decide o estado; o IntegraNotas (mais completo) só preenche as lacunas. A latência real medida é herdada quando a fonte vencedora não a reporta.
- Passa a ser o **motor padrão** das três pontas (api, collector, worker), mantendo um único motor para os números baterem entre elas.

### Fase 2 — Frescor do dado oficial

- `CollectedStatus` e `ServiceStatusDTO` ganham `sourceCheckedAt` (HH:MM:SS em que a própria SEFAZ aferiu o serviço; hoje só o SVRS publica). Campo **opcional** — snapshots antigos seguem válidos.
- O `ServiceCard` exibe discretamente **"✓ aferido pela SEFAZ às HH:MM"** — sinal mais honesto que a latência de acesso ao terceiro.

## Validação

- **121 testes** passando, typecheck e lint limpos em todo o monorepo.
- **Smoke ao vivo** contra as fontes reais: ~135 serviços coletados; SVRS vence ~112, página da Receita ~6, IntegraNotas preenche ~17; 112/135 chegam com `sourceCheckedAt` real.

## Fora de escopo

A latência real por UF continua **bloqueada sem certificado A1** (caminho SOAP). Verifiquei: os certificados de teste do repositório `nfephp-org/sped-nfe` são autoassinados (sem cadeia ICP-Brasil) e não servem para a coleta. O frescor por serviço (fase 2) é o melhor proxy disponível sem certificado.
