### PR TITLE
fix: modo soap (carregamento de .env + endpoints SEFAZ) e correções da auditoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ A forma mais simples é abrir o site:
 
 ### 🌐 **[felipesauer.github.io/monitor-sefaz](https://felipesauer.github.io/monitor-sefaz/)**
 
-Os dados são atualizados automaticamente a cada 15 minutos por um GitHub Actions.
+Os dados são atualizados automaticamente de hora em hora por um GitHub Actions.
 Clique em qualquer serviço para ver o histórico de uptime e latência.
 
 ## ⚙️ Rodando localmente
@@ -167,8 +167,9 @@ Não para o uso padrão — a fonte é a página pública de disponibilidade. O
 certificado só é necessário no modo `soap` (consulta direta aos webservices).
 
 **Os dados são em tempo real?**
-No GitHub Pages, atualizam a cada 15 min (cron do Actions). Nos modos Worker e
-self-host, são ao vivo / a cada checagem do scheduler.
+No GitHub Pages, atualizam de hora em hora (cron do Actions; a granularidade
+sub-horária não é honrada de forma confiável pelo agendador do GitHub). Nos modos
+Worker e self-host, são ao vivo / a cada checagem do scheduler.
 
 **Posso hospedar a minha própria instância?**
 Sim — em qualquer um dos três modos. Faça um fork e ajuste a URL do Pages, ou

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -9,8 +9,10 @@ export interface AppConfig {
   readonly environments: ('production' | 'homologation')[];
   /**
    * Fonte de status:
-   * - `hybrid`: IntegraNotas (JSON) + fallback ao scraping — padrão. Mesmo motor
-   *   do collector e do worker, para os números baterem entre as três pontas.
+   * - `hybrid`: consenso multi-fonte com precedência oficial (`ConsensusCollector`
+   *   — SVRS e página da Receita decidem o estado, o IntegraNotas preenche as
+   *   lacunas) — padrão. Mesmo motor do collector e do worker, para os números
+   *   baterem entre as três pontas.
    * - `availability`: só o scraping da página oficial (pública, sem cert).
    * - `soap`: consulta SOAP direta (exige rede/cert A1).
    */

--- a/apps/api/src/routes/statusRoutes.ts
+++ b/apps/api/src/routes/statusRoutes.ts
@@ -1,5 +1,6 @@
 import type { FastifyInstance } from 'fastify';
 import {
+  DocumentType,
   historyQuerySchema,
   statusQuerySchema,
   type EnvironmentValue,
@@ -7,6 +8,16 @@ import {
 import type { StatusStore } from '../store/StatusStore.js';
 import { SummaryService } from '../services/SummaryService.js';
 import { UptimeCalculator } from '../services/UptimeCalculator.js';
+
+/**
+ * Resolve o parâmetro de documento da rota para o valor canônico do enum
+ * (case-insensitive): "nfe"/"NFE" → `DocumentType.NFe`. Retorna `undefined` se
+ * não corresponder a nenhum documento conhecido.
+ */
+function normalizeDocument(raw: string): DocumentType | undefined {
+  const lower = raw.toLowerCase();
+  return Object.values(DocumentType).find((d) => d.toLowerCase() === lower);
+}
 
 export interface StatusRoutesDeps {
   readonly store: StatusStore;
@@ -41,7 +52,11 @@ export function registerStatusRoutes(app: FastifyInstance, deps: StatusRoutesDep
     '/api/v1/status/:document/:uf',
     async (request, reply) => {
       const env = statusQuerySchema.parse(request.query).env;
-      const id = `${request.params.document}:${request.params.uf.toUpperCase()}`;
+      // Normaliza o document para o enum canônico do catálogo (case-sensitive,
+      // ex.: "NFe") — o cliente pode passar "nfe"; a uf idem. Sem isso o id não
+      // casaria com o armazenado (`NFe:SP`) e a rota devolveria 404 espúrio.
+      const document = normalizeDocument(request.params.document);
+      const id = `${document ?? request.params.document}:${request.params.uf.toUpperCase()}`;
       const service = await store.getService(env, id);
       if (!service) {
         return reply.code(404).send({ message: 'Serviço não encontrado' });

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { Redis } from 'ioredis';
@@ -18,8 +18,30 @@ import { SoapStatusSource } from './sources/SoapStatusSource.js';
 import { AvailabilityStatusSource } from './sources/AvailabilityStatusSource.js';
 import { HybridStatusSource } from './sources/HybridStatusSource.js';
 
+/**
+ * Carrega variáveis de um arquivo `.env` para `process.env` (Node ≥20.12), sem
+ * dependência externa. Procura o `.env` na raiz do monorepo (dois níveis acima
+ * de apps/api) e, como fallback, no diretório de trabalho atual. Variáveis já
+ * definidas no ambiente têm precedência (o .env não sobrescreve). Se o arquivo
+ * não existir, segue silenciosamente — em produção as vars vêm do ambiente.
+ */
+function loadDotEnv(): void {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const candidates = [resolve(here, '../../../.env'), resolve(process.cwd(), '.env')];
+  for (const path of candidates) {
+    if (!existsSync(path)) continue;
+    try {
+      process.loadEnvFile(path);
+    } catch {
+      // arquivo ilegível/malformado: ignora e usa só o ambiente do processo
+    }
+    return;
+  }
+}
+
 /** Entrypoint: conecta o Redis, monta a API e inicia o scheduler de checagens. */
 async function main(): Promise<void> {
+  loadDotEnv();
   const config = loadConfig();
   const redis = new Redis(config.redisUrl, { maxRetriesPerRequest: null });
   // Conexão dedicada para subscribe (não pode emitir comandos normais).

--- a/apps/api/test/routes/statusRoutes.test.ts
+++ b/apps/api/test/routes/statusRoutes.test.ts
@@ -97,6 +97,12 @@ describe('statusRoutes', () => {
     expect(res.statusCode).toBe(404);
   });
 
+  it('GET /api/v1/status/:document/:uf normaliza document/uf minúsculos', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/v1/status/nfe/sp' });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().id).toBe('NFe:SP');
+  });
+
   it('GET /api/v1/services/:id/uptime retorna uptime conforme schema', async () => {
     const res = await app.inject({
       method: 'GET',

--- a/packages/catalog/src/endpoints.ts
+++ b/packages/catalog/src/endpoints.ts
@@ -20,21 +20,21 @@ type DocumentEndpoints = Record<EnvironmentKey, EndpointMap>;
 const NFE_ENDPOINTS: DocumentEndpoints = {
   production: {
     AM: 'https://nfe.sefaz.am.gov.br/services2/services/NfeStatusServico2',
-    BA: 'https://nfe.sefaz.ba.gov.br/webservices/NfeStatusServico2/NfeStatusServico2.asmx',
+    BA: 'https://nfe.sefaz.ba.gov.br/webservices/NFeStatusServico4/NFeStatusServico4.asmx',
     CE: 'https://nfe.sefaz.ce.gov.br/nfe2/services/NFeStatusServico4',
     GO: 'https://nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4',
     MG: 'https://nfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4',
-    MS: 'https://nfe.sefaz.ms.gov.br/ws2/NfeStatusServico2.asmx',
+    MS: 'https://nfe.sefaz.ms.gov.br/ws/NFeStatusServico4',
     MT: 'https://nfe.sefaz.mt.gov.br/nfews/v2/services/Nfews',
     PA: 'https://app.sefa.pa.gov.br/sfz-nfe-web/webservices/NfeStatusServico2',
-    PE: 'https://nfenw.sefaz.pe.gov.br/ws/NfeStatusServico2.asmx',
+    PE: 'https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4',
     PR: 'https://nfe.sefa.pr.gov.br/nfe/NFeStatusServico4',
-    RS: 'https://nfe.sefazrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
-    SP: 'https://nfe.fazenda.sp.gov.br/ws/nfestatus.asmx',
+    RS: 'https://nfe.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
+    SP: 'https://nfe.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx',
     SVAN: 'https://www.sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
-    SVRS: 'https://nfe.svrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
+    SVRS: 'https://nfe.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
     SVCAN: 'https://www.svc.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
-    SVCRS: 'https://nfe.svrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
+    SVCRS: 'https://nfe.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
     AN: 'https://www.nfe.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
   },
   homologation: {
@@ -43,17 +43,17 @@ const NFE_ENDPOINTS: DocumentEndpoints = {
     CE: 'https://nfeh.sefaz.ce.gov.br/nfe2/services/NFeStatusServico4',
     GO: 'https://homologacao.nfe.sefaz.go.gov.br/nfe/services/NFeStatusServico4',
     MG: 'https://hnfe.fazenda.mg.gov.br/nfe2/services/NFeStatusServico4',
-    MS: 'https://homologacao.nfe.sefaz.ms.gov.br/ws2/NfeStatusServico2.asmx',
+    MS: 'https://hom.nfe.sefaz.ms.gov.br/ws/NFeStatusServico4',
     MT: 'https://homologacao.sefaz.mt.gov.br/nfews/v2/services/Nfews',
     PA: 'https://app.sefa.pa.gov.br/sfz-nfe-web-hml/webservices/NfeStatusServico2',
-    PE: 'https://nfehomolog.sefaz.pe.gov.br/ws/NfeStatusServico2.asmx',
+    PE: 'https://nfe.sefaz.pe.gov.br/nfe-service/services/NFeStatusServico4',
     PR: 'https://homologacao.nfe.sefa.pr.gov.br/nfe/NFeStatusServico4',
-    RS: 'https://nfe-homologacao.sefazrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
-    SP: 'https://homologacao.nfe.fazenda.sp.gov.br/ws/nfestatus.asmx',
+    RS: 'https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
+    SP: 'https://homologacao.nfe.fazenda.sp.gov.br/ws/NFeStatusServico4.asmx',
     SVAN: 'https://hom.sefazvirtual.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
-    SVRS: 'https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
+    SVRS: 'https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
     SVCAN: 'https://hom.svc.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
-    SVCRS: 'https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatus/NfeStatus2.asmx',
+    SVCRS: 'https://nfe-homologacao.svrs.rs.gov.br/ws/NfeStatusServico/NfeStatusServico4.asmx',
     AN: 'https://hom.nfe.fazenda.gov.br/NFeStatusServico4/NFeStatusServico4.asmx',
   },
 };
@@ -68,10 +68,10 @@ const CTE_ENDPOINTS: DocumentEndpoints = {
     MS: 'https://producao.cte.ms.gov.br/ws/CTeStatusServicoV4',
     MT: 'https://cte.sefaz.mt.gov.br/ctews2/services/CTeStatusServicoV4',
     PR: 'https://cte.fazenda.pr.gov.br/cte4/CTeStatusServicoV4',
-    RS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
+    RS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     SP: 'https://nfe.fazenda.sp.gov.br/CTeWS/WS/CTeStatusServicoV4.asmx',
-    SVRS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
-    SVCRS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
+    SVRS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
+    SVCRS: 'https://cte.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     SVCAN: 'https://www.cte.fazenda.gov.br/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     AN: 'https://www.cte.fazenda.gov.br/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
   },
@@ -80,10 +80,10 @@ const CTE_ENDPOINTS: DocumentEndpoints = {
     MS: 'https://homologacao.cte.ms.gov.br/ws/CTeStatusServicoV4',
     MT: 'https://homologacao.cte.sefaz.mt.gov.br/ctews2/services/CTeStatusServicoV4',
     PR: 'https://homologacao.cte.fazenda.pr.gov.br/cte4/CTeStatusServicoV4',
-    RS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
+    RS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     SP: 'https://homologacao.nfe.fazenda.sp.gov.br/CTeWS/WS/CTeStatusServicoV4.asmx',
-    SVRS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
-    SVCRS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServico/CTeStatusServico.asmx',
+    SVRS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
+    SVCRS: 'https://cte-homologacao.svrs.rs.gov.br/ws/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     SVCAN: 'https://hom.cte.fazenda.gov.br/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
     AN: 'https://hom.cte.fazenda.gov.br/CTeStatusServicoV4/CTeStatusServicoV4.asmx',
   },
@@ -105,15 +105,17 @@ const MDFE_ENDPOINTS: DocumentEndpoints = {
 };
 
 /**
- * Endpoints DC-e (Declaração de Conteúdo eletrônica). Documento novo,
- * centralizado no SVRS.
+ * Endpoints DC-e (Declaração de Conteúdo eletrônica). Documento novo: o ambiente
+ * nacional da DC-e passou a ser hospedado pela SEFAZ-PR (`dce.fazenda.pr.gov.br`),
+ * não mais em `dce.svrs.rs.gov.br` (host descontinuado). O autorizador continua
+ * sendo o SVRS no catálogo (mapa UF→autorizador), só a URL do WS migrou.
  */
 const DCE_ENDPOINTS: DocumentEndpoints = {
   production: {
-    SVRS: 'https://dce.svrs.rs.gov.br/ws/dceStatusServico/dceStatusServico.asmx',
+    SVRS: 'https://dce.fazenda.pr.gov.br/dce/DCeStatusServico',
   },
   homologation: {
-    SVRS: 'https://dce-homologacao.svrs.rs.gov.br/ws/dceStatusServico/dceStatusServico.asmx',
+    SVRS: 'https://homologacao.dce.fazenda.pr.gov.br/dce/DCeStatusServico',
   },
 };
 


### PR DESCRIPTION
## Contexto

Auditoria do projeto + investigação do modo `soap` (STATUS_SOURCE=soap com certificado A1), que "não funcionava". A investigação revelou **dois bugs encadeados** — corrigidos e validados contra a SEFAZ real — além de correções de auditoria (rota e docs).

## Bugs corrigidos

### 1. A API não carregava o `.env` (causa raiz do modo soap)
A API lia toda a config de `process.env`, mas **nada carregava o arquivo `.env`** (`dotenv` não era dependência, nenhum `--env-file`). Com `pnpm dev`, o `.env` era ignorado: `STATUS_SOURCE` caía no default `hybrid` e `SEFAZ_CERT_PATH` ficava vazio → o modo `soap` **nunca ativava**.

**Correção:** `loadDotEnv()` no topo de `main()` usando `process.loadEnvFile()` (nativo do Node ≥20.12, sem dependência nova). Procura o `.env` na raiz do monorepo e cai para o cwd; variáveis já no ambiente têm precedência.

### 2. Endpoints SOAP desatualizados
Com o `.env` carregando, o SOAP finalmente rodou e expôs endpoints quebrados. Uma varredura das **27 UFs × 5 documentos** com cert A1 achou **7 endpoints únicos** retornando 404/HTML ou com DNS morto. Todos revalidados (HTTP 200 + XML SOAP):

| Documento | Autorizador | Problema | Correção |
| --- | --- | --- | --- |
| NFe (+NFCe) | SP | `nfestatus.asmx` → 404 | `NFeStatusServico4.asmx` |
| NFe | RS/SVRS/SVCRS | `NfeStatus2.asmx` → 404 | `NfeStatusServico/NfeStatusServico4.asmx` |
| NFe | BA | `NfeStatusServico2` → 404 | `NFeStatusServico4/NFeStatusServico4.asmx` |
| NFe | MS | `ws2/…Servico2.asmx` → 404 | `ws/NFeStatusServico4` |
| NFe | PE | `nfenw.sefaz.pe.gov.br` → DNS morto | `nfe.sefaz.pe.gov.br/nfe-service/…` |
| CTe | RS/SVRS/SVCRS | `CTeStatusServico.asmx` → 404 | `CTeStatusServicoV4/CTeStatusServicoV4.asmx` |
| DCe | SVRS | `dce.svrs.rs.gov.br` → DNS morto | **migrou p/ SEFAZ-PR** `dce.fazenda.pr.gov.br/dce/DCeStatusServico` |

> A DC-e mudou de autorizador: o host do SVRS foi descontinuado e o ambiente nacional passou a ser hospedado pela SEFAZ-PR (confirmado no portal oficial `dfe-portal.svrs.rs.gov.br/Dce`). Corrige produção e homologação.

### 3. Normalização do `document` na rota `/status/:document/:uf`
A rota normalizava a `uf` (`toUpperCase`) mas não o `document`. Como `DocumentType` é case-sensitive (`NFe`), `/status/nfe/sp` gerava o id `nfe:SP` que não casava com o armazenado (`NFe:SP`) → 404 espúrio. Adiciona `normalizeDocument` + teste.

### 4. Docs desatualizados
- README: "15 minutos" → "de hora em hora", alinhado ao cron real do Actions (`17 * * * *`).
- `config.ts`: comentário do `STATUS_SOURCE=hybrid` descrevia o `HybridCollector` antigo; o motor real é o `ConsensusCollector`.

## Validação

- ✅ `pnpm typecheck`, `pnpm lint`, `pnpm test` (todos verdes)
- ✅ API real subida em modo `soap`: `Rodada production [soap]: 135 serviços` — lê o `.env`, carrega o cert A1, coleta e persiste no Redis
- ✅ Os 19 endpoints únicos respondem SOAP (antes: 7 quebrados)

> Nota: com certificado **e-CPF** a maioria das SEFAZ responde `cStat 282 (cert sem CNPJ)`; só GO/BA/PE dão `107`. Status completo via SOAP exige um **A1 de CNPJ** — limitação do certificado, não do código.
