### PR TITLE
feat(core): endurece coleta contra drift silencioso do portal

### DIFF
--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -10,9 +10,11 @@ import {
   type HistoryFileDTO,
   type HistoryPointDTO,
   type ServiceStatusDTO,
+  type SourceHealthDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
 } from '@monitor-sefaz/contracts';
+import type { SourceHealth } from '@monitor-sefaz/core';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -23,7 +25,31 @@ const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60
  */
 const MIN_COVERAGE_RATIO = Number(process.env.MIN_COVERAGE_RATIO ?? DEFAULT_MIN_COVERAGE_RATIO);
 
-function buildSummary(services: ServiceStatusDTO[], generatedAt: string): SummaryDTO {
+/**
+ * Converte a saúde por fonte do consenso (core) para o DTO do contrato. O `source`
+ * do core é o rótulo livre da fonte; no consenso padrão coincide com o enum
+ * `statusSource` (svrs/availability/integranotas). Fontes com rótulo fora do enum
+ * são descartadas do diagnóstico (não quebram o summary).
+ */
+function toSourceHealthDTOs(sources: SourceHealth[]): SourceHealthDTO[] {
+  const KNOWN = new Set(['integranotas', 'availability', 'svrs']);
+  return sources
+    .filter((s) => KNOWN.has(s.source))
+    .map((s) => ({
+      source: s.source as SourceHealthDTO['source'],
+      official: s.official,
+      collected: s.collected,
+      expected: s.expected,
+      coverage: s.coverage,
+      degraded: s.degraded,
+    }));
+}
+
+function buildSummary(
+  services: ServiceStatusDTO[],
+  generatedAt: string,
+  sources?: SourceHealth[]
+): SummaryDTO {
   const total = services.length;
   const operational = services.filter((s) => isUp(s.state)).length;
   const group = (keyOf: (s: ServiceStatusDTO) => string): SummaryDTO['byDocument'] => {
@@ -54,6 +80,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
     avgLatencyMs: averageLatency(latencies),
     byDocument: group((s) => s.document),
     byAuthorizer: group((s) => s.authorizer),
+    ...(sources ? { sources: toSourceHealthDTOs(sources) } : {}),
   };
 }
 
@@ -112,14 +139,14 @@ async function main(): Promise<void> {
   // Fonte multi-fonte com precedência oficial: SVRS e página oficial da Receita
   // (oficiais) decidem o estado; o IntegraNotas (mais completo) preenche as UFs
   // que as oficiais não publicam.
-  const collector = ConsensusCollector.createForNode();
-  const collected = await collector.collect();
+  const catalog = new Catalog();
+  const collector = ConsensusCollector.createForNode(catalog, MIN_COVERAGE_RATIO);
+  const { services: collected, sources: sourceHealth } = await collector.collectWithDiagnostics();
 
   // Guarda de piso: se a coleta veio muito abaixo do catálogo, ambas as fontes
   // provavelmente falharam. Abortar com erro (sem escrever) faz o git não ver
   // diff — o último snapshot bom permanece — e o GitHub Actions falha visível,
   // em vez de publicar services:[] / availability:0 silenciosamente.
-  const catalog = new Catalog();
   if (!catalog.meetsCoverageFloor(collected.length, Environment.Production, MIN_COVERAGE_RATIO)) {
     const expected = catalog.listAll(Environment.Production).length;
     console.error(
@@ -147,7 +174,7 @@ async function main(): Promise<void> {
   }));
 
   const snapshot: StatusSnapshotDTO = { environment: 'production', generatedAt, services };
-  const summary = buildSummary(services, generatedAt);
+  const summary = buildSummary(services, generatedAt, sourceHealth);
   const history = appendHistory(loadHistory(join(outDir, 'history.json')), services, generatedAt);
 
   writeFileSync(join(outDir, 'status.json'), JSON.stringify(snapshot, null, 2));

--- a/apps/worker/src/WorkerAvailabilityProvider.ts
+++ b/apps/worker/src/WorkerAvailabilityProvider.ts
@@ -1,7 +1,10 @@
 import {
   AvailabilityParser,
   AVAILABILITY_URLS,
+  backoffMs,
+  defaultSleeper,
   type AvailabilityRow,
+  type Sleeper,
 } from '@monitor-sefaz/core';
 import { DocumentType } from '@monitor-sefaz/catalog';
 
@@ -18,6 +21,13 @@ const BROWSER_UA =
  * que funciona em Workers).
  */
 export class WorkerAvailabilityProvider {
+  constructor(
+    /** Sleeper do backoff entre tentativas; injetável para os testes não dormirem. */
+    private readonly sleep: Sleeper = defaultSleeper,
+    /** Fonte de aleatoriedade do jitter; injetável para o backoff ser determinístico. */
+    private readonly random: () => number = Math.random
+  ) {}
+
   public supportedDocuments(): DocumentType[] {
     return Object.keys(AVAILABILITY_URLS) as DocumentType[];
   }
@@ -33,25 +43,39 @@ export class WorkerAvailabilityProvider {
     // (página sem a tabela) de forma intermitente. NÃO há fallback de
     // homologação: o ambiente é distinto e reportaria status errado.
     let lastError: unknown;
+    const totalAttempts = urls.length * attemptsPerUrl;
+    let attemptIndex = 0;
     for (const url of urls) {
       for (let attempt = 1; attempt <= attemptsPerUrl; attempt += 1) {
+        attemptIndex += 1;
         try {
-          const rows = await this.fetchOne(url, parser);
-          if (rows.length > 0) {
+          const { rows, headerMatched } = await this.fetchOne(url, parser);
+          // Paridade com o Node: só confia nas linhas se o cabeçalho validou o
+          // layout. Sem isso, esvazia a fonte (→ degraded no consenso) em vez de
+          // publicar leitura de colunas possivelmente erradas.
+          if (rows.length > 0 && headerMatched) {
             return rows;
           }
+          lastError = new Error(
+            headerMatched ? 'resposta sem linhas de status' : 'layout inesperado: cabeçalho não reconhecido'
+          );
         } catch (err) {
           lastError = err;
         }
+        // Backoff antes da PRÓXIMA tentativa (paridade com o caminho Node): dá
+        // tempo de uma falha transitória passar e não martela a SEFAZ.
+        if (attemptIndex < totalAttempts) {
+          await this.sleep(backoffMs(attempt, this.random));
+        }
       }
     }
-    if (lastError) {
-      throw lastError instanceof Error ? lastError : new Error(String(lastError));
-    }
-    return [];
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
-  private async fetchOne(url: string, parser: AvailabilityParser): Promise<AvailabilityRow[]> {
+  private async fetchOne(
+    url: string,
+    parser: AvailabilityParser
+  ): Promise<{ rows: AvailabilityRow[]; headerMatched: boolean }> {
     const headers: Record<string, string> = {
       'User-Agent': BROWSER_UA,
       Accept: 'text/html,application/xhtml+xml',
@@ -75,8 +99,11 @@ export class WorkerAvailabilityProvider {
       }
     }
 
-    const html = await response.text();
-    return parser.parse(html);
+    // A página é latin-1; o Worker não tem Buffer. Decodificamos via TextDecoder
+    // (paridade com o caminho Node, que faz `Buffer.toString('latin1')`, e com o
+    // fetcher SVRS do Worker). Usar `.text()` assumiria UTF-8 e corromperia acentos.
+    const html = new TextDecoder('latin1').decode(await response.arrayBuffer());
+    return parser.parseWithDiagnostics(html);
   }
 
   /**

--- a/apps/worker/test/WorkerAvailabilityProvider.test.ts
+++ b/apps/worker/test/WorkerAvailabilityProvider.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { DocumentType } from '@monitor-sefaz/catalog';
+import { AvailabilityParser } from '@monitor-sefaz/core';
+import { WorkerAvailabilityProvider } from '../src/WorkerAvailabilityProvider.js';
+
+// A fixture é a página REAL da Receita, salva em latin-1 (mesma usada nos testes
+// do core). Reaproveitamos o caminho do fixture do pacote core.
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+  here,
+  '..',
+  '..',
+  '..',
+  'packages',
+  'core',
+  'test',
+  'fixtures',
+  'availability',
+  'nfe-disponibilidade.html'
+);
+// Bytes crus latin-1 (não decodificados) — é isso que a rede entrega.
+const fixtureLatin1Bytes = readFileSync(fixturePath, 'latin1');
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Response falso servindo os bytes latin-1 da fixture (sem redirect). */
+function latin1Response(): Response {
+  // Recria o array de bytes a partir da string latin-1 (1 char = 1 byte).
+  const bytes = Uint8Array.from(fixtureLatin1Bytes, (c) => c.charCodeAt(0));
+  return new Response(bytes, { status: 200 });
+}
+
+describe('WorkerAvailabilityProvider — paridade com o caminho Node', () => {
+  it('decodifica latin-1 e produz o MESMO resultado que o parser do core', async () => {
+    globalThis.fetch = (async () => latin1Response()) as typeof fetch;
+
+    const provider = new WorkerAvailabilityProvider();
+    const workerRows = await provider.fetch(DocumentType.NFe);
+
+    // Referência: o parser do core sobre a MESMA fixture decodificada como latin-1
+    // (é como o collector Node faz via Buffer.toString('latin1')).
+    const expected = new AvailabilityParser(DocumentType.NFe).parse(fixtureLatin1Bytes);
+
+    expect(workerRows.length).toBeGreaterThan(0);
+    expect(workerRows).toEqual(expected);
+  });
+
+  it('faz backoff entre tentativas e tem sucesso após falha transitória', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('conexão recusada (transitória)');
+      return latin1Response();
+    }) as typeof fetch;
+
+    const delays: number[] = [];
+    const provider = new WorkerAvailabilityProvider(
+      async (ms) => {
+        delays.push(ms);
+      },
+      () => 0.5 // jitter neutro → backoff = 500 × attempt
+    );
+    const rows = await provider.fetch(DocumentType.NFe);
+
+    expect(calls).toBe(2);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(delays).toEqual([500]); // um backoff entre a 1ª e a 2ª tentativa
+  });
+
+  it('esvazia a fonte quando o layout muda (cabeçalho irreconhecível), mesmo com linhas', async () => {
+    // Página com linhas de dados plausíveis, mas SEM um cabeçalho que casa
+    // "status"/"tempo" → drift. Confiar nessas linhas leria colunas erradas; o
+    // provider trata como falha (esvazia → degraded no consenso) em vez de publicar.
+    const driftHtml = `<table>
+      <tr><th>Coluna A</th><th>Coluna B</th><th>Coluna C</th><th>Coluna D</th>
+          <th>Coluna E</th><th>Coluna F</th></tr>
+      <tr><td>SP</td><td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+          <td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+          <td><img src="bola_verde.png"></td></tr>
+    </table>`;
+    const bytes = Uint8Array.from(driftHtml, (c) => c.charCodeAt(0));
+    globalThis.fetch = (async () => new Response(bytes, { status: 200 })) as typeof fetch;
+
+    const provider = new WorkerAvailabilityProvider(async () => {}, () => 0.5);
+    // Sem cabeçalho reconhecível em nenhuma tentativa → lança (fonte vazia).
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/layout inesperado/);
+  });
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -97,6 +97,26 @@ export const summaryGroupSchema = z.object({
   availability: z.number(),
 });
 
+/**
+ * Saúde de UMA fonte na última coleta. `degraded` sinaliza DRIFT: uma fonte que
+ * normalmente cobre a maior parte do catálogo veio muito abaixo do piso — indício
+ * de que o portal mudou o HTML e o parser parou de casar, em vez de uma queda real
+ * da SEFAZ (que retornaria os serviços com estado DOWN/ERROR, não ausentes).
+ */
+export const sourceHealthSchema = z.object({
+  source: statusSourceSchema,
+  official: z.boolean(),
+  /** Serviços que a fonte devolveu nesta coleta. */
+  collected: z.number(),
+  /** Total de serviços do catálogo (referência de cobertura). */
+  expected: z.number(),
+  /** collected / expected, 0..1, arredondado a 3 casas. */
+  coverage: z.number(),
+  /** coverage abaixo do piso → provável drift do portal. */
+  degraded: z.boolean(),
+});
+export type SourceHealthDTO = z.infer<typeof sourceHealthSchema>;
+
 export const summarySchema = z.object({
   environment: environmentSchema,
   generatedAt: z.string(),
@@ -107,6 +127,11 @@ export const summarySchema = z.object({
   avgLatencyMs: z.number().nullable(),
   byDocument: z.array(summaryGroupSchema),
   byAuthorizer: z.array(summaryGroupSchema),
+  /**
+   * Diagnóstico por fonte da última coleta (opcional para retrocompat com
+   * summaries antigos que não o traziam). Base do sinal de drift.
+   */
+  sources: z.array(sourceHealthSchema).optional(),
 });
 export type SummaryDTO = z.infer<typeof summarySchema>;
 

--- a/packages/core/src/availability/AvailabilityParser.ts
+++ b/packages/core/src/availability/AvailabilityParser.ts
@@ -11,6 +11,17 @@ export interface AvailabilityRow {
 }
 
 /**
+ * Resultado do parse com diagnóstico de layout. `headerMatched` indica se a coluna
+ * de status foi resolvida pelo TEXTO do cabeçalho (robusto a mudança de layout) ou
+ * se caímos no índice fixo — um `false` com página não-vazia é indício de DRIFT do
+ * HTML da SEFAZ, sinal que o consenso pode transformar em alerta.
+ */
+export interface AvailabilityParseResult {
+  readonly rows: AvailabilityRow[];
+  readonly headerMatched: boolean;
+}
+
+/**
  * Layout de colunas da tabela de disponibilidade — VARIA por documento.
  * `statusIndex` é a coluna "Status Serviço"; `tMedIndex` é a coluna "Tempo Médio".
  *
@@ -41,6 +52,37 @@ function colorToState(src: string): ServiceState | null {
   if (src.includes('bola_amarela')) return ServiceState.SlowDown;
   if (src.includes('bola_vermelh')) return ServiceState.Down;
   return null;
+}
+
+/** Normaliza texto de cabeçalho: minúsculo, sem acento e sem não-letras. */
+function normalizeHeader(raw: string): string {
+  return raw
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // remove diacríticos
+    .replace(/[^a-z]/g, ''); // "Status Serviço4" → "statusservico"
+}
+
+/**
+ * Descobre os índices das colunas "Status Serviço" e "Tempo Médio" pelo TEXTO do
+ * cabeçalho (`<th>`), tolerante a inserção/remoção de colunas pela SEFAZ. Retorna
+ * `null` quando o cabeçalho não casa (aí o chamador usa o índice fixo como
+ * fallback e sinaliza que o layout pode ter mudado).
+ */
+function findColumnsByHeader(
+  headerCells: string[]
+): { statusIndex: number; tMedIndex: number } | null {
+  const norm = headerCells.map(normalizeHeader);
+  // Casa por âncoras ASCII estáveis ("status", "tempo") em vez do texto completo:
+  // a página vem em latin-1 e "Serviço"/"Médio" chegam como mojibake ("serviao"),
+  // mas "Status" e "Tempo" não têm acento e sobrevivem à decodificação.
+  const statusIndex = norm.findIndex((h) => h.includes('status'));
+  const tMedIndex = norm.findIndex((h) => h.includes('tempo'));
+  if (statusIndex < 0) {
+    return null; // sem a coluna-chave, não confiamos no cabeçalho
+  }
+  // tMed pode não existir em alguns layouts; -1 é aceitável (vira null no parse).
+  return { statusIndex, tMedIndex };
 }
 
 function normalizeAuthorizer(raw: string): AuthorizerCode {
@@ -75,9 +117,33 @@ export class AvailabilityParser {
   }
 
   public parse(html: string): AvailabilityRow[] {
+    return this.parseWithDiagnostics(html).rows;
+  }
+
+  /**
+   * Como `parse`, mas informa se a coluna de status foi resolvida pelo cabeçalho
+   * (`headerMatched: true`) ou pelo índice fixo de fallback. Prefere SEMPRE o
+   * cabeçalho — casar "Status Serviço"/"Tempo Médio" pelo texto sobrevive à
+   * SEFAZ inserir/remover colunas; o índice fixo só entra quando o cabeçalho não
+   * casa, e nesse caso `headerMatched: false` sinaliza possível drift.
+   */
+  public parseWithDiagnostics(html: string): AvailabilityParseResult {
     const $ = cheerio.load(html);
+
+    // Tenta resolver as colunas pelo cabeçalho da PRIMEIRA linha que tem <th>.
+    let resolved: { statusIndex: number; tMedIndex: number } | null = null;
+    $('tr').each((_, tr) => {
+      if (resolved) return;
+      const ths = $(tr).find('th');
+      if (ths.length > 2) {
+        const headers = ths.map((_i, th) => $(th).text()).get();
+        resolved = findColumnsByHeader(headers);
+      }
+    });
+
+    const headerMatched = resolved !== null;
+    const { statusIndex, tMedIndex } = resolved ?? this.layout;
     const rows: AvailabilityRow[] = [];
-    const { statusIndex, tMedIndex } = this.layout;
 
     $('tr').each((_, tr) => {
       const cells = $(tr).find('td');
@@ -96,7 +162,9 @@ export class AvailabilityParser {
         return; // coluna sem bolinha de status → não é uma linha de dados
       }
 
-      const tMedText = cells.eq(tMedIndex).text().trim();
+      // tMedIndex pode ser -1 (cabeçalho sem "Tempo Médio"): eq(-1) não casa,
+      // texto vazio → tMedSeconds null. Comportamento correto, sem exceção.
+      const tMedText = tMedIndex >= 0 ? cells.eq(tMedIndex).text().trim() : '';
       const tMedMatch = tMedText.match(/\d+/);
 
       rows.push({
@@ -106,6 +174,6 @@ export class AvailabilityParser {
       });
     });
 
-    return rows;
+    return { rows, headerMatched };
   }
 }

--- a/packages/core/src/availability/AvailabilityProvider.ts
+++ b/packages/core/src/availability/AvailabilityProvider.ts
@@ -2,7 +2,12 @@ import axios, { type AxiosInstance } from 'axios';
 import { wrapper } from 'axios-cookiejar-support';
 import { CookieJar } from 'tough-cookie';
 import { DocumentType } from '@monitor-sefaz/catalog';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 import { AvailabilityParser, type AvailabilityRow } from './AvailabilityParser.js';
+
+// Reexporta o backoff/Sleeper compartilhado para não quebrar importações antigas
+// que apontam para este módulo (ex.: SvrsProvider e os testes).
+export { backoffMs, type Sleeper };
 
 /**
  * URLs das páginas oficiais de disponibilidade de PRODUÇÃO, por documento, em
@@ -32,19 +37,6 @@ const BROWSER_UA =
  * loop de redirect sem cookies; por isso usamos um cookie jar e um User-Agent
  * de browser. Esta é a mesma estratégia de monitores públicos da SEFAZ.
  */
-/** Espera `ms` antes de resolver. Injetável para os testes não dormirem de verdade. */
-export type Sleeper = (ms: number) => Promise<void>;
-const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Atraso (ms) antes da próxima tentativa: linear (500ms × tentativa) com jitter
- * de ±20%. `attempt` é 1-based; `random` deve devolver [0,1). Função pura para
- * ser testável de forma determinística.
- */
-export function backoffMs(attempt: number, random: () => number = Math.random): number {
-  return Math.round(500 * attempt * (0.8 + random() * 0.4));
-}
-
 export class HttpAvailabilityProvider {
   private readonly http: AxiosInstance;
 
@@ -103,11 +95,20 @@ export class HttpAvailabilityProvider {
         try {
           const response = await this.http.get<ArrayBuffer>(url);
           const html = Buffer.from(response.data).toString('latin1');
-          const rows = parser.parse(html);
-          if (rows.length > 0) {
+          const { rows, headerMatched } = parser.parseWithDiagnostics(html);
+          // Só confiamos nas linhas se o layout foi VALIDADO pelo cabeçalho. Se o
+          // cabeçalho não casou (headerMatched=false), o HTML pode ter mudado e as
+          // linhas viriam de colunas erradas — tratamos como falha de parse, que
+          // esvazia esta fonte e a marca `degraded` no consenso (sinal de drift),
+          // em vez de publicar dado possivelmente incorreto em silêncio.
+          if (rows.length > 0 && headerMatched) {
             return rows;
           }
-          lastError = new Error(`resposta sem linhas de status (HTTP ${response.status})`);
+          lastError = new Error(
+            headerMatched
+              ? `resposta sem linhas de status (HTTP ${response.status})`
+              : `layout inesperado: cabeçalho não reconhecido (HTTP ${response.status})`
+          );
         } catch (err) {
           lastError = err;
         }

--- a/packages/core/src/consensus/ConsensusCollector.ts
+++ b/packages/core/src/consensus/ConsensusCollector.ts
@@ -1,4 +1,4 @@
-import { Catalog } from '@monitor-sefaz/catalog';
+import { Catalog, Environment, DEFAULT_MIN_COVERAGE_RATIO } from '@monitor-sefaz/catalog';
 import {
   AvailabilityCollector,
   type CollectedStatus,
@@ -21,6 +21,28 @@ export interface ConsensusSource {
 }
 
 /**
+ * Saúde de uma fonte numa coleta — quanto do catálogo ela cobriu e se está
+ * `degraded` (indício de drift do portal). `expected` é o total do catálogo, não
+ * a cobertura teórica exata da fonte: o sinal que importa é uma fonte que costuma
+ * trazer a maior parte dos serviços despencar para quase nada (parser parou de
+ * casar após mudança de HTML), não medir sua fração ideal ao decimal.
+ */
+export interface SourceHealth {
+  readonly source: string;
+  readonly official: boolean;
+  readonly collected: number;
+  readonly expected: number;
+  readonly coverage: number;
+  readonly degraded: boolean;
+}
+
+/** Resultado do consenso com o diagnóstico por fonte anexado. */
+export interface ConsensusResult {
+  readonly services: CollectedStatus[];
+  readonly sources: SourceHealth[];
+}
+
+/**
  * Coletor MULTI-FONTE com PRECEDÊNCIA OFICIAL.
  *
  * Substitui o `HybridCollector` (que era failover A→B) por um cruzamento real:
@@ -39,7 +61,12 @@ export interface ConsensusSource {
 export class ConsensusCollector implements StatusCollectorLike {
   public readonly name = 'consensus';
 
-  constructor(private readonly sources: ConsensusSource[]) {}
+  constructor(
+    private readonly sources: ConsensusSource[],
+    private readonly catalog = new Catalog(),
+    /** Piso de cobertura por fonte abaixo do qual ela é marcada `degraded`. */
+    private readonly minCoverageRatio = DEFAULT_MIN_COVERAGE_RATIO
+  ) {}
 
   /**
    * Consenso padrão para Node, em ordem de precedência:
@@ -47,31 +74,59 @@ export class ConsensusCollector implements StatusCollectorLike {
    * mais completo). Mesmo motor para api, collector (Actions) e — quando portado —
    * o Worker.
    */
-  public static createForNode(catalog = new Catalog()): ConsensusCollector {
-    return new ConsensusCollector([
-      {
-        name: 'svrs',
-        official: true,
-        collector: new SvrsCollector(new SvrsProvider(createHttpSvrsFetcher()), catalog),
-      },
-      {
-        name: 'availability',
-        official: true,
-        collector: new AvailabilityCollector(new HttpAvailabilityProvider(), catalog),
-      },
-      {
-        name: 'integranotas',
-        official: false,
-        collector: IntegraNotasCollector.create(createHttpIntegraNotasFetcher(), catalog),
-      },
-    ]);
+  public static createForNode(
+    catalog = new Catalog(),
+    minCoverageRatio = DEFAULT_MIN_COVERAGE_RATIO
+  ): ConsensusCollector {
+    return new ConsensusCollector(
+      [
+        {
+          name: 'svrs',
+          official: true,
+          collector: new SvrsCollector(new SvrsProvider(createHttpSvrsFetcher()), catalog),
+        },
+        {
+          name: 'availability',
+          official: true,
+          collector: new AvailabilityCollector(new HttpAvailabilityProvider(), catalog),
+        },
+        {
+          name: 'integranotas',
+          official: false,
+          collector: IntegraNotasCollector.create(createHttpIntegraNotasFetcher(), catalog),
+        },
+      ],
+      catalog,
+      minCoverageRatio
+    );
   }
 
   public async collect(): Promise<CollectedStatus[]> {
+    const { services } = await this.collectWithDiagnostics();
+    return services;
+  }
+
+  /**
+   * Como `collect()`, mas também devolve a saúde por fonte (cobertura + `degraded`)
+   * — o sinal de drift do portal. A API/worker/collector usam `collect()`; quem
+   * quer o diagnóstico (o `summary.json`) chama este método.
+   */
+  public async collectWithDiagnostics(): Promise<ConsensusResult> {
     const settled = await Promise.allSettled(this.sources.map((s) => s.collector.collect()));
     const results = settled.map((r, i) => ({
       source: this.sources[i]!,
       statuses: r.status === 'fulfilled' ? r.value : [],
+    }));
+
+    const expected = this.catalog.listAll(Environment.Production).length;
+    const floor = Math.floor(expected * this.minCoverageRatio);
+    const sourceHealth: SourceHealth[] = results.map(({ source, statuses }) => ({
+      source: source.name,
+      official: source.official,
+      collected: statuses.length,
+      expected,
+      coverage: expected === 0 ? 0 : Number((statuses.length / expected).toFixed(3)),
+      degraded: statuses.length < floor,
     }));
 
     const key = (s: CollectedStatus): string => `${s.document}:${s.uf}`;
@@ -106,6 +161,6 @@ export class ConsensusCollector implements StatusCollectorLike {
       }
     }
 
-    return [...winners.values()];
+    return { services: [...winners.values()], sources: sourceHealth };
   }
 }

--- a/packages/core/src/domain/retry.ts
+++ b/packages/core/src/domain/retry.ts
@@ -1,0 +1,22 @@
+/**
+ * Utilitários de retry/backoff compartilhados pelas fontes ao vivo (Availability,
+ * SVRS e IntegraNotas). Ficam no domínio — e não em uma fonte específica — porque
+ * os três providers seguem a MESMA política: algumas tentativas com backoff linear
+ * e jitter, já que os portais da SEFAZ e a API do IntegraNotas ocasionalmente
+ * recusam a conexão ou devolvem uma resposta vazia de forma transitória.
+ */
+
+/** Espera `ms` antes de resolver. Injetável para os testes não dormirem de verdade. */
+export type Sleeper = (ms: number) => Promise<void>;
+
+/** Sleeper padrão baseado em `setTimeout`. */
+export const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Atraso (ms) antes da próxima tentativa: linear (500ms × tentativa) com jitter
+ * de ±20%. `attempt` é 1-based; `random` deve devolver [0,1). Função pura para
+ * ser testável de forma determinística.
+ */
+export function backoffMs(attempt: number, random: () => number = Math.random): number {
+  return Math.round(500 * attempt * (0.8 + random() * 0.4));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type { UF, AuthorizerCode } from '@monitor-sefaz/catalog';
 // Domínio
 export * from './domain/types.js';
 export * from './domain/errors.js';
+export { backoffMs, defaultSleeper, type Sleeper } from './domain/retry.js';
 
 // Envelopes (Strategy por documento)
 export type { EnvelopeBuilder, EnvelopeParams } from './envelopes/EnvelopeBuilder.js';
@@ -52,6 +53,7 @@ export {
   AvailabilityParser,
   DOCUMENT_COLUMNS,
   type AvailabilityRow,
+  type AvailabilityParseResult,
   type ColumnLayout,
 } from './availability/AvailabilityParser.js';
 export {
@@ -89,4 +91,9 @@ export { createHttpSvrsFetcher } from './svrs/httpFetcher.js';
 export { SvrsCollector } from './svrs/SvrsCollector.js';
 
 // Consenso multi-fonte (precedência oficial)
-export { ConsensusCollector, type ConsensusSource } from './consensus/ConsensusCollector.js';
+export {
+  ConsensusCollector,
+  type ConsensusSource,
+  type SourceHealth,
+  type ConsensusResult,
+} from './consensus/ConsensusCollector.js';

--- a/packages/core/src/integranotas/IntegraNotasProvider.ts
+++ b/packages/core/src/integranotas/IntegraNotasProvider.ts
@@ -1,5 +1,6 @@
 import { DocumentType, type UF } from '@monitor-sefaz/catalog';
 import { ServiceState } from '../domain/types.js';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 
 /** Status por UF de um documento, como exposto pelo IntegraNotas. */
 export interface IntegraNotasRow {
@@ -88,18 +89,47 @@ export class IntegraNotasProvider {
   constructor(
     private readonly fetcher: IntegraNotasFetcher,
     /** Relógio em ms; injetável para os testes serem determinísticos. */
-    private readonly now: () => number = () => Date.now()
+    private readonly now: () => number = () => Date.now(),
+    /** Sleeper do backoff entre tentativas; injetável para os testes não dormirem. */
+    private readonly sleep: Sleeper = defaultSleeper,
+    /** Fonte de aleatoriedade do jitter; injetável para o backoff ser determinístico. */
+    private readonly random: () => number = Math.random
   ) {}
 
   public supportedDocuments(): DocumentType[] {
     return Object.keys(INTEGRANOTAS_DOCUMENTS) as DocumentType[];
   }
 
-  public async fetch(document: DocumentType): Promise<IntegraNotasFetchResult> {
+  /**
+   * Busca e parseia a disponibilidade de um documento. Tenta algumas vezes com
+   * backoff: o IntegraNotas é a única fonte que cobre UF-a-UF de forma completa
+   * (preenche as lacunas das oficiais no consenso), então uma falha transitória
+   * de rede aqui deixaria várias UFs sem dado. Como nas demais fontes ao vivo, se
+   * todas as tentativas falharem LANÇA — o `IntegraNotasCollector` então pula o
+   * documento (parse estrito, para não mascarar as fontes oficiais).
+   */
+  public async fetch(document: DocumentType, attempts = 3): Promise<IntegraNotasFetchResult> {
     const slug = INTEGRANOTAS_DOCUMENTS[document];
     if (!slug) {
       return { rows: [], fetchLatencyMs: 0 };
     }
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        return await this.fetchOnce(slug);
+      } catch (err) {
+        lastError = err;
+      }
+      if (attempt < attempts) {
+        await this.sleep(backoffMs(attempt, this.random));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /** Uma única tentativa: fetch cronometrado + parse estrito dos arrays paralelos. */
+  private async fetchOnce(slug: string): Promise<IntegraNotasFetchResult> {
     // Cronometra a requisição: esta é a latência de REDE real do documento — a
     // métrica que o front exibe. O tMed do IntegraNotas é tempo médio da SEFAZ
     // em segundos inteiros (grosseiro: 0/1/6s), inútil como latência.
@@ -112,7 +142,7 @@ export class IntegraNotasProvider {
     // backgroundColor[i], normal[i], svc[i]). Se qualquer um desalinhar, lemos o
     // estado/flags de OUTRA UF ou caímos em Error silencioso. Por isso exigimos
     // que todos os presentes tenham o mesmo comprimento de labels; senão lança e
-    // o HybridCollector pula o documento (e cai no fallback se necessário).
+    // o IntegraNotasCollector pula o documento (o consenso segue com as demais fontes).
     const n = d?.labels?.length;
     const lenMismatch = (a?: unknown[]): boolean => Array.isArray(a) && a.length !== n;
     if (

--- a/packages/core/src/svrs/SvrsProvider.ts
+++ b/packages/core/src/svrs/SvrsProvider.ts
@@ -1,5 +1,5 @@
 import { DocumentType } from '@monitor-sefaz/catalog';
-import { backoffMs, type Sleeper } from '../availability/AvailabilityProvider.js';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 import { SvrsParser, type SvrsAuthorizerStatus } from './SvrsParser.js';
 
 /**
@@ -17,8 +17,6 @@ export const SVRS_URLS: Partial<Record<DocumentType, string>> = {
   [DocumentType.MDFe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
   [DocumentType.DCe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
 };
-
-const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Transporte HTTP injetável (axios no Node via `createHttpSvrsFetcher`, fetch

--- a/packages/core/test/availability/AvailabilityParser.test.ts
+++ b/packages/core/test/availability/AvailabilityParser.test.ts
@@ -79,4 +79,53 @@ describe('AvailabilityParser', () => {
   it('ignora HTML sem tabela de status', () => {
     expect(parser.parse('<html><body><p>sem tabela</p></body></html>')).toEqual([]);
   });
+
+  describe('resolução por cabeçalho (defensivo a mudança de layout)', () => {
+    it('nas páginas reais, resolve as colunas pelo cabeçalho (headerMatched)', () => {
+      const nfe = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(
+        loadAvailability('nfe-disponibilidade.html')
+      );
+      const cte = new AvailabilityParser(DocumentType.CTe).parseWithDiagnostics(
+        loadAvailability('cte-disponibilidade.html')
+      );
+      expect(nfe.headerMatched).toBe(true);
+      expect(cte.headerMatched).toBe(true);
+      expect(nfe.rows.length).toBeGreaterThanOrEqual(12);
+      expect(cte.rows.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('acha a coluna certa pelo cabeçalho mesmo com layout deslocado', () => {
+      // Cabeçalho diz que "Status Serviço" é a coluna 3 (não a 5 do layout NF-e).
+      // Uma coluna nova foi inserida; o índice fixo leria a coluna errada.
+      const html = `<table>
+        <tr><th>Autorizador</th><th>Coluna Nova</th><th>Autorização</th>
+            <th>Status Serviço</th><th>Retorno</th><th>Consulta</th><th>Tempo Médio</th></tr>
+        <tr>
+          <td>SP</td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_verde.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td>2</td>
+        </tr></table>`;
+      // Parser com layout NF-e (statusIndex fixo=5), mas o cabeçalho manda.
+      const res = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(html);
+      expect(res.headerMatched).toBe(true);
+      expect(res.rows[0]?.state).toBe(ServiceState.Operational); // coluna 3 (verde), não a 5
+      expect(res.rows[0]?.tMedSeconds).toBe(2); // "Tempo Médio" achado na coluna 6
+    });
+
+    it('cai no índice fixo e sinaliza headerMatched=false quando não há cabeçalho', () => {
+      // HTML sem <th>: não dá para validar o layout → fallback + sinal de drift.
+      const html = `<table><tr>
+        <td>SP</td><td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+        <td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+        <td><img src="bola_verde.png"></td><td>1</td>
+      </tr></table>`;
+      const res = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(html);
+      expect(res.headerMatched).toBe(false); // sem cabeçalho → possível drift
+      expect(res.rows[0]?.state).toBe(ServiceState.Operational); // fallback índice 5 ainda funciona
+    });
+  });
 });

--- a/packages/core/test/availability/backoff.test.ts
+++ b/packages/core/test/availability/backoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { backoffMs } from '../../src/availability/AvailabilityProvider.js';
+import { backoffMs } from '../../src/domain/retry.js';
 
 describe('backoffMs', () => {
   it('é linear na tentativa (base 500ms × attempt) sem jitter', () => {

--- a/packages/core/test/consensus/ConsensusCollector.test.ts
+++ b/packages/core/test/consensus/ConsensusCollector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DocumentType, type UF } from '@monitor-sefaz/catalog';
+import { Catalog, DocumentType, type UF } from '@monitor-sefaz/catalog';
 import { ConsensusCollector } from '../../src/consensus/ConsensusCollector.js';
 import { ServiceState } from '../../src/domain/types.js';
 import type { CollectedStatus } from '../../src/availability/AvailabilityCollector.js';
@@ -98,5 +98,74 @@ describe('ConsensusCollector', () => {
     const out = await consensus.collect();
     expect(out).toHaveLength(1);
     expect(out[0]!.source).toBe('integranotas');
+  });
+
+  describe('collectWithDiagnostics (sinal de drift)', () => {
+    // expected = 135 (5 docs × 27 UFs em produção). Com ratio 0.015, floor = 2:
+    // uma fonte com 1 serviço fica degraded; com 2+ fica saudável. Assim testamos
+    // os dois lados sem montar 100+ serviços à mão.
+    const RATIO = 0.015;
+
+    it('reporta cobertura por fonte e marca degraded abaixo do piso', async () => {
+      // svrs traz só 1 serviço (degraded); integranotas traz 3 (saudável).
+      const svrs = fake([status('SP', ServiceState.Operational, 'svrs')]);
+      const third = fake([
+        status('SP', ServiceState.Operational, 'integranotas'),
+        status('AM', ServiceState.Operational, 'integranotas'),
+        status('BA', ServiceState.Operational, 'integranotas'),
+      ]);
+      const consensus = new ConsensusCollector(
+        [
+          { name: 'svrs', official: true, collector: svrs },
+          { name: 'integranotas', official: false, collector: third },
+        ],
+        new Catalog(),
+        RATIO
+      );
+
+      const { services, sources } = await consensus.collectWithDiagnostics();
+      // Os serviços continuam saindo como sempre (SP decidido pela oficial).
+      expect(services.find((s) => s.uf === 'SP')!.source).toBe('svrs');
+
+      const svrsHealth = sources.find((s) => s.source === 'svrs')!;
+      expect(svrsHealth.collected).toBe(1);
+      expect(svrsHealth.expected).toBe(135);
+      expect(svrsHealth.degraded).toBe(true); // 1 < floor(135*0.015)=2 → drift
+
+      const thirdHealth = sources.find((s) => s.source === 'integranotas')!;
+      expect(thirdHealth.collected).toBe(3);
+      expect(thirdHealth.degraded).toBe(false); // 3 ≥ 2 → saudável
+    });
+
+    it('uma fonte que lança fica com collected=0 e degraded=true', async () => {
+      const broken = fake([], true);
+      const ok = fake([
+        status('SP', ServiceState.Operational, 'integranotas'),
+        status('AM', ServiceState.Operational, 'integranotas'),
+      ]);
+      const consensus = new ConsensusCollector(
+        [
+          { name: 'svrs', official: true, collector: broken },
+          { name: 'integranotas', official: false, collector: ok },
+        ],
+        new Catalog(),
+        RATIO
+      );
+
+      const { sources } = await consensus.collectWithDiagnostics();
+      const svrsHealth = sources.find((s) => s.source === 'svrs')!;
+      expect(svrsHealth.collected).toBe(0);
+      expect(svrsHealth.degraded).toBe(true);
+      expect(svrsHealth.official).toBe(true);
+    });
+
+    it('collect() continua devolvendo só os serviços (retrocompat)', async () => {
+      const consensus = new ConsensusCollector([
+        { name: 'svrs', official: true, collector: fake([status('SP', ServiceState.Operational, 'svrs')]) },
+      ]);
+      const out = await consensus.collect();
+      expect(Array.isArray(out)).toBe(true);
+      expect(out[0]!.uf).toBe('SP');
+    });
   });
 });

--- a/packages/core/test/integranotas/IntegraNotasProvider.test.ts
+++ b/packages/core/test/integranotas/IntegraNotasProvider.test.ts
@@ -51,18 +51,21 @@ describe('IntegraNotasProvider', () => {
     expect(fetchLatencyMs).toBe(137);
   });
 
+  // Sleeper fake para os testes de erro não dormirem os retries de verdade.
+  const skipSleep = async (): Promise<void> => {};
+
   it('lança quando o payload não tem dados.labels', async () => {
-    const provider = new IntegraNotasProvider(async () => '{"dados":{}}');
+    const provider = new IntegraNotasProvider(async () => '{"dados":{}}', undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow();
   });
 
   it('lança quando há labels/backgroundColor mas falta o array data', async () => {
     // Sem essa guarda, todas as UFs virariam Error silenciosamente (tMed=-1) e o
-    // fallback do híbrido nunca dispararia.
+    // consenso não saberia que a fonte falhou.
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto/);
   });
 
@@ -70,7 +73,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''], data: [1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto|desalinhad/);
   });
 
@@ -78,7 +81,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: [''], data: [1, 1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/desalinhad|incompleto/);
   });
 
@@ -86,7 +89,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''], data: [1, 1], normal: [1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/desalinhad|incompleto/);
   });
 
@@ -96,5 +99,47 @@ describe('IntegraNotasProvider', () => {
     expect(docs).toContain(DocumentType.MDFe);
     expect(docs).toContain(DocumentType.DCe);
     expect(docs).toHaveLength(5);
+  });
+
+  // Sleeper fake: não dorme de verdade, só registra os atrasos pedidos.
+  const noSleep = (delays: number[]) => async (ms: number) => {
+    delays.push(ms);
+  };
+  const fixedRandom = (): number => 0.5; // jitter neutro → backoff = 500 × attempt
+
+  it('faz retry com backoff e tem sucesso após uma falha transitória', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const provider = new IntegraNotasProvider(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('ECONNRESET transitório');
+        return nfeFixture;
+      },
+      () => 0,
+      noSleep(delays),
+      fixedRandom
+    );
+    const { rows } = await provider.fetch(DocumentType.NFe);
+    expect(calls).toBe(2); // falhou 1×, sucesso na 2ª
+    expect(rows).toHaveLength(27);
+    expect(delays).toEqual([500]); // um backoff entre a 1ª e a 2ª tentativa
+  });
+
+  it('lança após esgotar as tentativas (parse estrito preservado)', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const provider = new IntegraNotasProvider(
+      async () => {
+        calls += 1;
+        throw new Error('sempre falha');
+      },
+      () => 0,
+      noSleep(delays),
+      fixedRandom
+    );
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/sempre falha/);
+    expect(calls).toBe(3); // attempts=3 por padrão
+    expect(delays).toEqual([500, 1000]); // backoff só ENTRE tentativas, não após a última
   });
 });

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,4 +4,5 @@ export default defineWorkspace([
   'packages/*',
   'apps/api',
   'apps/web',
+  'apps/worker',
 ]);


### PR DESCRIPTION
## Contexto

Endurece o scraping das páginas de disponibilidade contra a quebra **silenciosa** que ocorre quando a Receita/SVRS mudam o HTML — sem alterar o consenso multi-fonte nem regredir o pipeline público. Hoje, se o parser de uma fonte para de casar, os serviços somem do snapshot daquela fonte e as demais cobrem, mascarando que uma fonte oficial morreu.

## O que muda

- **retry**: extrai `backoff`/`Sleeper` para `core/domain/retry.ts` (antes viviam em `AvailabilityProvider`) e aplica retry+backoff ao `IntegraNotasProvider`, única fonte que cobre UF-a-UF de forma completa e não tinha retry.
- **paridade Node↔Worker**: `WorkerAvailabilityProvider` decodifica latin-1 via `TextDecoder` (era `.text()`, corrompia acentos) e aplica backoff entre tentativas, alinhando ao caminho do collector.
- **drift observável**: `ConsensusCollector.collectWithDiagnostics()` computa cobertura por fonte e um flag `degraded` abaixo do piso, exposto no `summary.json` (novo bloco `sources`). `collect()` delega e é retrocompatível.
- **parser defensivo**: `AvailabilityParser` resolve as colunas "Status"/"Tempo" pelo texto do cabeçalho (âncoras ASCII, robustas ao mojibake latin-1), com o índice fixo como fallback. Os providers só confiam nas linhas se o cabeçalho validar o layout; caso contrário esvaziam a fonte, que então entra como `degraded` no consenso em vez de publicar colunas erradas.
- adiciona `apps/worker` ao `vitest.workspace` com testes de paridade e drift.

## Compatibilidade

Nenhuma assinatura pública muda: `collect()`, `AvailabilityProviderLike` e `AvailabilityParser.parse()` continuam iguais. O campo `sources` no `summary.json` é opcional (summaries antigos seguem válidos).

## Verificação

- `pnpm test` — core 83, worker 3, todos os pacotes verdes
- `pnpm typecheck` e `pnpm lint` — verdes
- collector real: coleta os 135 serviços sem regressão; o `summary.json` passa a trazer o diagnóstico por fonte