### PR TITLE
feat: endurecimento do scraping + sistema de notificações (Fases 1–8)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,18 @@ RATE_LIMIT_MAX=120
 # Porta exposta no host pelo docker-compose
 # APP_PORT=3333
 # REDIS_PORT=6379
+
+# --- Notificações externas (opcional) --------------------------------------
+# Cada canal só é ativado quando SUAS variáveis existem. Sem nenhuma delas, a
+# notificação fica desligada (no-op) e o pipeline segue idêntico.
+# Discord: URL do webhook do canal.
+# NOTIFY_DISCORD_WEBHOOK_URL=
+# Slack: URL do Incoming Webhook.
+# NOTIFY_SLACK_WEBHOOK_URL=
+# Telegram: token do bot E id do chat (ambos obrigatórios).
+# NOTIFY_TELEGRAM_BOT_TOKEN=
+# NOTIFY_TELEGRAM_CHAT_ID=
+# Webhook genérico: recebe o evento como JSON cru.
+# NOTIFY_WEBHOOK_URL=
+# Filtro de tipos (csv). Vazio = todos. Ex.: SERVICE_DOWN,SERVICE_RECOVERED
+# NOTIFY_EVENTS=

--- a/.env.example
+++ b/.env.example
@@ -52,3 +52,5 @@ RATE_LIMIT_MAX=120
 # NOTIFY_WEBHOOK_URL=
 # Filtro de tipos (csv). Vazio = todos. Ex.: SERVICE_DOWN,SERVICE_RECOVERED
 # NOTIFY_EVENTS=
+# Resumo diário: hora UTC (0–23) em que o digest é enviado. Vazio = desligado.
+# NOTIFY_DIGEST_HOUR=

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Valida o monorepo em cada PR e em pushes para main: lint, typecheck e testes.
+# O turbo cuida da ordem (build das libs antes dos testes que delas dependem).
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+# Evita rodar CI redundante: um novo push na mesma ref cancela o anterior.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Testes
+        run: pnpm test

--- a/.github/workflows/collect.yml
+++ b/.github/workflows/collect.yml
@@ -44,6 +44,16 @@ jobs:
 
       - name: Coletar status
         run: pnpm --filter @monitor-sefaz/collector collect "$GITHUB_WORKSPACE/apps/web/public/data"
+        env:
+          # Notificações (opcional): definidas como secrets/vars do repositório.
+          # Ausentes → o collector é no-op de notificação (nenhum efeito).
+          NOTIFY_DISCORD_WEBHOOK_URL: ${{ secrets.NOTIFY_DISCORD_WEBHOOK_URL }}
+          NOTIFY_SLACK_WEBHOOK_URL: ${{ secrets.NOTIFY_SLACK_WEBHOOK_URL }}
+          NOTIFY_TELEGRAM_BOT_TOKEN: ${{ secrets.NOTIFY_TELEGRAM_BOT_TOKEN }}
+          NOTIFY_TELEGRAM_CHAT_ID: ${{ secrets.NOTIFY_TELEGRAM_CHAT_ID }}
+          NOTIFY_WEBHOOK_URL: ${{ secrets.NOTIFY_WEBHOOK_URL }}
+          NOTIFY_EVENTS: ${{ vars.NOTIFY_EVENTS }}
+          NOTIFY_DIGEST_HOUR: ${{ vars.NOTIFY_DIGEST_HOUR }}
 
       - name: Commitar dados atualizados
         run: |

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -15,6 +15,7 @@
     "@monitor-sefaz/catalog": "workspace:*",
     "@monitor-sefaz/contracts": "workspace:*",
     "@monitor-sefaz/core": "workspace:*",
+    "@monitor-sefaz/notifier": "workspace:*",
     "@fastify/cors": "^10.0.1",
     "@fastify/rate-limit": "^10.2.1",
     "@fastify/static": "^8.0.3",

--- a/apps/api/src/scheduler/Scheduler.ts
+++ b/apps/api/src/scheduler/Scheduler.ts
@@ -70,7 +70,18 @@ export class Scheduler {
         const key = `${env}:${service.id}`;
         const previous = this.lastState.get(key);
         if (previous !== undefined) {
-          prev.push({ ...service, state: previous as ServiceStatusDTO['state'] });
+          // Reconstrói o estado anterior carregando SÓ o `state` de fato antigo;
+          // os demais campos (cStat/source/latency) do snapshot atual são apenas
+          // preenchimento identitário (id/uf/document não mudam para o mesmo
+          // serviço). O `cStat`/`source` reais de antes não são guardados no
+          // lastState — e o diff só compara `state`, então não os inventamos:
+          // zeramos cStat/source para não passar valores enganosos.
+          prev.push({
+            ...service,
+            state: previous as ServiceStatusDTO['state'],
+            cStat: null,
+            source: undefined,
+          });
         }
         this.lastState.set(key, service.state);
         return previous !== undefined && previous !== service.state;

--- a/apps/api/src/scheduler/Scheduler.ts
+++ b/apps/api/src/scheduler/Scheduler.ts
@@ -1,5 +1,6 @@
 import cron, { type ScheduledTask } from 'node-cron';
-import { type EnvironmentValue } from '@monitor-sefaz/contracts';
+import { type EnvironmentValue, type ServiceStatusDTO } from '@monitor-sefaz/contracts';
+import { detectTransitions, type Notifier } from '@monitor-sefaz/notifier';
 import type { StatusStore } from '../store/StatusStore.js';
 import type { StatusSource } from '../sources/StatusSource.js';
 
@@ -28,7 +29,9 @@ export class Scheduler {
     private readonly source: StatusSource,
     private readonly store: StatusStore,
     private readonly options: SchedulerOptions,
-    private readonly logger: SchedulerLogger
+    private readonly logger: SchedulerLogger,
+    /** Notificador opcional; quando habilitado, dispara eventos de transição. */
+    private readonly notifier?: Notifier
   ) {}
 
   /** Inicia o cron e dispara uma rodada imediata. */
@@ -60,15 +63,30 @@ export class Scheduler {
         return;
       }
 
+      // Reconstrói o estado ANTERIOR (para o diff de eventos) e detecta os serviços
+      // que mudaram — tudo lendo o lastState antes de atualizá-lo.
+      const prev: ServiceStatusDTO[] = [];
       const changed = services.filter((service) => {
         const key = `${env}:${service.id}`;
         const previous = this.lastState.get(key);
+        if (previous !== undefined) {
+          prev.push({ ...service, state: previous as ServiceStatusDTO['state'] });
+        }
         this.lastState.set(key, service.state);
         return previous !== undefined && previous !== service.state;
       });
 
       await this.store.saveSnapshot(env, services);
       await this.store.publishUpdates(env, changed);
+
+      // Notificação externa (opcional): reusa a MESMA detecção de transições do
+      // caminho do collector, mantendo uma só semântica de eventos. No-op se o
+      // Notifier não tiver canais configurados.
+      if (this.notifier?.enabled && changed.length > 0) {
+        const events = detectTransitions(prev, services, new Date().toISOString());
+        const { sent, failed } = await this.notifier.notify(events);
+        this.logger.info(`Notificações ${env}: ${events.length} eventos, ${sent} ok, ${failed} falha`);
+      }
 
       this.logger.info(
         `Rodada ${env} [${this.source.name}]: ${services.length} serviços, ${changed.length} mudança(s)`

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -8,6 +8,7 @@ import {
   CheckerFactory,
   type ClientCertificate,
 } from '@monitor-sefaz/core';
+import { Notifier, parseNotifierConfig } from '@monitor-sefaz/notifier';
 import { loadConfig } from './config.js';
 import { buildApp } from './app.js';
 import { RedisStatusStore } from './store/RedisStatusStore.js';
@@ -93,11 +94,18 @@ async function main(): Promise<void> {
     logger: true,
   });
 
+  // Notificador externo (opcional): ativo só se houver NOTIFY_* no ambiente.
+  const notifier = new Notifier(parseNotifierConfig(process.env));
+  if (notifier.enabled) {
+    app.log.info('Notificações externas habilitadas');
+  }
+
   const scheduler = new Scheduler(
     source,
     store,
     { cronExpression: config.cronExpression, environments: config.environments },
-    { info: (m) => app.log.info(m), error: (m) => app.log.error(m) }
+    { info: (m) => app.log.info(m), error: (m) => app.log.error(m) },
+    notifier
   );
 
   const shutdown = async (): Promise<void> => {

--- a/apps/api/test/scheduler/Scheduler.test.ts
+++ b/apps/api/test/scheduler/Scheduler.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
-import type { EnvironmentValue, ServiceStatusDTO } from '@monitor-sefaz/contracts';
+import type {
+  EnvironmentValue,
+  NotificationEventDTO,
+  ServiceStatusDTO,
+} from '@monitor-sefaz/contracts';
+import type { Notifier } from '@monitor-sefaz/notifier';
 import { Scheduler } from '../../src/scheduler/Scheduler.js';
 import type { StatusStore } from '../../src/store/StatusStore.js';
 import type { StatusSource } from '../../src/sources/StatusSource.js';
@@ -75,5 +80,43 @@ describe('Scheduler', () => {
 
     await scheduler.runOnce('homologation');
     expect(store.saveSnapshot).not.toHaveBeenCalled();
+  });
+
+  it('notifica os eventos de transição, mas não no baseline', async () => {
+    const store = makeStore();
+    const notify = vi.fn(async () => ({ sent: 1, failed: 0 }));
+    const notifier = { enabled: true, notify } as unknown as Notifier;
+    const scheduler = new Scheduler(
+      makeSource(['OPERATIONAL', 'DOWN']),
+      store,
+      opts,
+      logger,
+      notifier
+    );
+
+    await scheduler.runOnce('production'); // baseline: sem changed → não notifica
+    expect(notify).not.toHaveBeenCalled();
+
+    await scheduler.runOnce('production'); // OPERATIONAL → DOWN
+    expect(notify).toHaveBeenCalledOnce();
+    const events = notify.mock.calls[0]![0] as NotificationEventDTO[];
+    expect(events.map((e) => e.type)).toEqual(['SERVICE_DOWN']);
+  });
+
+  it('não chama notify quando o Notifier está desabilitado', async () => {
+    const store = makeStore();
+    const notify = vi.fn(async () => ({ sent: 0, failed: 0 }));
+    const notifier = { enabled: false, notify } as unknown as Notifier;
+    const scheduler = new Scheduler(
+      makeSource(['OPERATIONAL', 'DOWN']),
+      store,
+      opts,
+      logger,
+      notifier
+    );
+
+    await scheduler.runOnce('production');
+    await scheduler.runOnce('production');
+    expect(notify).not.toHaveBeenCalled();
   });
 });

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../../packages/catalog" },
     { "path": "../../packages/core" },
-    { "path": "../../packages/contracts" }
+    { "path": "../../packages/contracts" },
+    { "path": "../../packages/notifier" }
   ]
 }

--- a/apps/collector/package.json
+++ b/apps/collector/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "@monitor-sefaz/catalog": "workspace:*",
     "@monitor-sefaz/contracts": "workspace:*",
-    "@monitor-sefaz/core": "workspace:*"
+    "@monitor-sefaz/core": "workspace:*",
+    "@monitor-sefaz/notifier": "workspace:*"
   },
   "devDependencies": {
     "@types/node": "^22.10.2",

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -10,9 +10,11 @@ import {
   type HistoryFileDTO,
   type HistoryPointDTO,
   type ServiceStatusDTO,
+  type SourceHealthDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
 } from '@monitor-sefaz/contracts';
+import type { SourceHealth } from '@monitor-sefaz/core';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -23,7 +25,31 @@ const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60
  */
 const MIN_COVERAGE_RATIO = Number(process.env.MIN_COVERAGE_RATIO ?? DEFAULT_MIN_COVERAGE_RATIO);
 
-function buildSummary(services: ServiceStatusDTO[], generatedAt: string): SummaryDTO {
+/**
+ * Converte a saúde por fonte do consenso (core) para o DTO do contrato. O `source`
+ * do core é o rótulo livre da fonte; no consenso padrão coincide com o enum
+ * `statusSource` (svrs/availability/integranotas). Fontes com rótulo fora do enum
+ * são descartadas do diagnóstico (não quebram o summary).
+ */
+function toSourceHealthDTOs(sources: SourceHealth[]): SourceHealthDTO[] {
+  const KNOWN = new Set(['integranotas', 'availability', 'svrs']);
+  return sources
+    .filter((s) => KNOWN.has(s.source))
+    .map((s) => ({
+      source: s.source as SourceHealthDTO['source'],
+      official: s.official,
+      collected: s.collected,
+      expected: s.expected,
+      coverage: s.coverage,
+      degraded: s.degraded,
+    }));
+}
+
+function buildSummary(
+  services: ServiceStatusDTO[],
+  generatedAt: string,
+  sources?: SourceHealth[]
+): SummaryDTO {
   const total = services.length;
   const operational = services.filter((s) => isUp(s.state)).length;
   const group = (keyOf: (s: ServiceStatusDTO) => string): SummaryDTO['byDocument'] => {
@@ -54,6 +80,7 @@ function buildSummary(services: ServiceStatusDTO[], generatedAt: string): Summar
     avgLatencyMs: averageLatency(latencies),
     byDocument: group((s) => s.document),
     byAuthorizer: group((s) => s.authorizer),
+    ...(sources ? { sources: toSourceHealthDTOs(sources) } : {}),
   };
 }
 
@@ -112,14 +139,14 @@ async function main(): Promise<void> {
   // Fonte multi-fonte com precedência oficial: SVRS e página oficial da Receita
   // (oficiais) decidem o estado; o IntegraNotas (mais completo) preenche as UFs
   // que as oficiais não publicam.
-  const collector = ConsensusCollector.createForNode();
-  const collected = await collector.collect();
+  const catalog = new Catalog();
+  const collector = ConsensusCollector.createForNode(catalog, MIN_COVERAGE_RATIO);
+  const { services: collected, sources: sourceHealth } = await collector.collectWithDiagnostics();
 
   // Guarda de piso: se a coleta veio muito abaixo do catálogo, ambas as fontes
   // provavelmente falharam. Abortar com erro (sem escrever) faz o git não ver
   // diff — o último snapshot bom permanece — e o GitHub Actions falha visível,
   // em vez de publicar services:[] / availability:0 silenciosamente.
-  const catalog = new Catalog();
   if (!catalog.meetsCoverageFloor(collected.length, Environment.Production, MIN_COVERAGE_RATIO)) {
     const expected = catalog.listAll(Environment.Production).length;
     console.error(
@@ -147,7 +174,7 @@ async function main(): Promise<void> {
   }));
 
   const snapshot: StatusSnapshotDTO = { environment: 'production', generatedAt, services };
-  const summary = buildSummary(services, generatedAt);
+  const summary = buildSummary(services, generatedAt, sourceHealth);
   const history = appendHistory(loadHistory(join(outDir, 'history.json')), services, generatedAt);
 
   writeFileSync(join(outDir, 'status.json'), JSON.stringify(snapshot, null, 2));

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -1,22 +1,30 @@
 import { mkdirSync, readFileSync, writeFileSync, existsSync } from 'node:fs';
 import { join, resolve } from 'node:path';
-import { ConsensusCollector } from '@monitor-sefaz/core';
+import {
+  ConsensusCollector,
+  TechnicalNotesProvider,
+  createHttpTechnicalNotesFetcher,
+} from '@monitor-sefaz/core';
 import { Catalog, DEFAULT_MIN_COVERAGE_RATIO, Environment } from '@monitor-sefaz/catalog';
 import {
   averageLatency,
   fromEnvironment,
   historyFileSchema,
   isUp,
+  technicalNotesFileSchema,
   type HistoryFileDTO,
   type HistoryPointDTO,
   type ServiceStatusDTO,
   type SourceHealthDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
+  type TechnicalNoteDTO,
+  type TechnicalNotesFileDTO,
 } from '@monitor-sefaz/contracts';
 import type { SourceHealth } from '@monitor-sefaz/core';
 import { Notifier, parseNotifierConfig } from '@monitor-sefaz/notifier';
 import { buildNotificationEvents } from './notifyEvents.js';
+import { reconcileTechnicalNotes, technicalNoteEvents } from './technicalNotes.js';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -94,6 +102,36 @@ function loadHistory(path: string): HistoryFileDTO {
     return historyFileSchema.parse(JSON.parse(readFileSync(path, 'utf8')));
   } catch {
     return { updatedAt: new Date(0).toISOString(), series: {} };
+  }
+}
+
+function loadTechnicalNotes(path: string): TechnicalNotesFileDTO {
+  if (!existsSync(path)) {
+    return { updatedAt: new Date(0).toISOString(), notes: [] };
+  }
+  try {
+    return technicalNotesFileSchema.parse(JSON.parse(readFileSync(path, 'utf8')));
+  } catch {
+    return { updatedAt: new Date(0).toISOString(), notes: [] };
+  }
+}
+
+/**
+ * Coleta as Notas Técnicas e reconcilia com o arquivo versionado, devolvendo as
+ * NTs novas para notificar. Tolerante a falha: se a coleta de NTs falhar, NÃO
+ * derruba a coleta de status — apenas não há NT nova nesta rodada.
+ */
+async function collectTechnicalNotes(outDir: string, now: string): Promise<TechnicalNoteDTO[]> {
+  const path = join(outDir, 'technical-notes.json');
+  try {
+    const provider = new TechnicalNotesProvider(createHttpTechnicalNotesFetcher());
+    const scraped = await provider.fetch();
+    const { file, fresh } = reconcileTechnicalNotes(loadTechnicalNotes(path), scraped, now);
+    writeFileSync(path, JSON.stringify(file, null, 2));
+    return fresh;
+  } catch (err) {
+    console.warn(`Notas Técnicas: coleta falhou (${err instanceof Error ? err.message : err})`);
+    return [];
   }
 }
 
@@ -190,12 +228,22 @@ async function main(): Promise<void> {
     `Coletado: ${services.length} serviços (${summary.operational} operacionais) → ${outDir}`
   );
 
+  // Notas Técnicas: coleta própria (não afeta o piso de status). Atualiza o
+  // technical-notes.json versionado e devolve as NTs novas para notificar.
+  const freshNotes = await collectTechnicalNotes(outDir, generatedAt);
+  if (freshNotes.length > 0) {
+    console.log(`Notas Técnicas: ${freshNotes.length} nova(s)`);
+  }
+
   // Notificação (opcional): compara com o estado anterior do histórico e dispara
   // os eventos aos canais configurados. Sem nenhuma var NOTIFY_*, é no-op. Roda
   // DEPOIS de publicar os JSONs — uma falha de entrega não deve impedir a coleta.
   const notifier = new Notifier(parseNotifierConfig(process.env));
   if (notifier.enabled) {
-    const events = buildNotificationEvents(previousHistory, services, summary.sources, generatedAt);
+    const events = [
+      ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
+      ...technicalNoteEvents(freshNotes, generatedAt),
+    ];
     const { sent, failed } = await notifier.notify(events);
     console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
   }

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -15,6 +15,8 @@ import {
   type SummaryDTO,
 } from '@monitor-sefaz/contracts';
 import type { SourceHealth } from '@monitor-sefaz/core';
+import { Notifier, parseNotifierConfig } from '@monitor-sefaz/notifier';
+import { buildNotificationEvents } from './notifyEvents.js';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -175,7 +177,10 @@ async function main(): Promise<void> {
 
   const snapshot: StatusSnapshotDTO = { environment: 'production', generatedAt, services };
   const summary = buildSummary(services, generatedAt, sourceHealth);
-  const history = appendHistory(loadHistory(join(outDir, 'history.json')), services, generatedAt);
+  // Carrega o histórico ANTES do append: o último ponto de cada série é o estado
+  // anterior contra o qual detectamos transições para notificar.
+  const previousHistory = loadHistory(join(outDir, 'history.json'));
+  const history = appendHistory(previousHistory, services, generatedAt);
 
   writeFileSync(join(outDir, 'status.json'), JSON.stringify(snapshot, null, 2));
   writeFileSync(join(outDir, 'summary.json'), JSON.stringify(summary, null, 2));
@@ -184,6 +189,16 @@ async function main(): Promise<void> {
   console.log(
     `Coletado: ${services.length} serviços (${summary.operational} operacionais) → ${outDir}`
   );
+
+  // Notificação (opcional): compara com o estado anterior do histórico e dispara
+  // os eventos aos canais configurados. Sem nenhuma var NOTIFY_*, é no-op. Roda
+  // DEPOIS de publicar os JSONs — uma falha de entrega não deve impedir a coleta.
+  const notifier = new Notifier(parseNotifierConfig(process.env));
+  if (notifier.enabled) {
+    const events = buildNotificationEvents(previousHistory, services, summary.sources, generatedAt);
+    const { sent, failed } = await notifier.notify(events);
+    console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
+  }
 }
 
 void main();

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -241,18 +241,25 @@ async function main(): Promise<void> {
   // DEPOIS de publicar os JSONs — uma falha de entrega não deve impedir a coleta.
   const notifier = new Notifier(parseNotifierConfig(process.env));
   if (notifier.enabled) {
-    const digest = buildDigestEvent(
-      summary,
-      parseDigestHour(process.env.NOTIFY_DIGEST_HOUR),
-      new Date(generatedAt)
-    );
-    const events = [
-      ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
-      ...technicalNoteEvents(freshNotes, generatedAt),
-      ...(digest ? [digest] : []),
-    ];
-    const { sent, failed } = await notifier.notify(events);
-    console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
+    // Envolto em try/catch: os JSONs já foram publicados acima. Uma falha aqui
+    // (montagem de evento, entrega) NÃO deve marcar o job como vermelho nem
+    // impedir a coleta — apenas registra o aviso.
+    try {
+      const digest = buildDigestEvent(
+        summary,
+        parseDigestHour(process.env.NOTIFY_DIGEST_HOUR),
+        new Date(generatedAt)
+      );
+      const events = [
+        ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
+        ...technicalNoteEvents(freshNotes, generatedAt),
+        ...(digest ? [digest] : []),
+      ];
+      const { sent, failed } = await notifier.notify(events);
+      console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
+    } catch (err) {
+      console.warn(`Notificação falhou (coleta preservada): ${err instanceof Error ? err.message : err}`);
+    }
   }
 }
 

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -25,6 +25,7 @@ import type { SourceHealth } from '@monitor-sefaz/core';
 import { Notifier, parseNotifierConfig } from '@monitor-sefaz/notifier';
 import { buildNotificationEvents } from './notifyEvents.js';
 import { reconcileTechnicalNotes, technicalNoteEvents } from './technicalNotes.js';
+import { buildDigestEvent, parseDigestHour } from './digest.js';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -240,9 +241,15 @@ async function main(): Promise<void> {
   // DEPOIS de publicar os JSONs — uma falha de entrega não deve impedir a coleta.
   const notifier = new Notifier(parseNotifierConfig(process.env));
   if (notifier.enabled) {
+    const digest = buildDigestEvent(
+      summary,
+      parseDigestHour(process.env.NOTIFY_DIGEST_HOUR),
+      new Date(generatedAt)
+    );
     const events = [
       ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
       ...technicalNoteEvents(freshNotes, generatedAt),
+      ...(digest ? [digest] : []),
     ];
     const { sent, failed } = await notifier.notify(events);
     console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);

--- a/apps/collector/src/digest.ts
+++ b/apps/collector/src/digest.ts
@@ -1,0 +1,39 @@
+import type { NotificationEventDTO, SummaryDTO } from '@monitor-sefaz/contracts';
+
+/**
+ * Decide se esta rodada deve emitir o resumo diário e, em caso afirmativo, monta o
+ * evento DAILY_DIGEST a partir do summary. Função PURA (recebe a hora atual).
+ *
+ * Gatilho SEM estado: o Actions roda de hora em hora, então emitimos o digest
+ * apenas quando a hora UTC atual == `targetHour`. `targetHour` vem de
+ * NOTIFY_DIGEST_HOUR (0–23); ausente/ inválido = digest desligado (retorna null).
+ * Isso evita persistir "já enviei hoje" — a granularidade horária do cron basta.
+ */
+export function buildDigestEvent(
+  summary: SummaryDTO,
+  targetHour: number | null,
+  now: Date
+): NotificationEventDTO | null {
+  if (targetHour === null || now.getUTCHours() !== targetHour) {
+    return null;
+  }
+  return {
+    type: 'DAILY_DIGEST',
+    occurredAt: now.toISOString(),
+    payload: {
+      total: summary.total,
+      operational: summary.operational,
+      failing: summary.failing,
+      availability: summary.availability,
+      avgLatencyMs: summary.avgLatencyMs,
+      degradedSources: (summary.sources ?? []).filter((s) => s.degraded).map((s) => s.source),
+    },
+  };
+}
+
+/** Interpreta NOTIFY_DIGEST_HOUR: inteiro 0–23 válido, senão null (desligado). */
+export function parseDigestHour(raw: string | undefined): number | null {
+  if (raw === undefined || raw.trim() === '') return null;
+  const n = Number(raw);
+  return Number.isInteger(n) && n >= 0 && n <= 23 ? n : null;
+}

--- a/apps/collector/src/notifyEvents.ts
+++ b/apps/collector/src/notifyEvents.ts
@@ -1,0 +1,74 @@
+import {
+  DocumentType,
+  type HistoryFileDTO,
+  type NotificationEventDTO,
+  type ServiceStatusDTO,
+  type SourceHealthDTO,
+} from '@monitor-sefaz/contracts';
+import { detectTransitions } from '@monitor-sefaz/notifier';
+
+/**
+ * Reconstrói o "estado anterior" por serviço a partir do history.json: o ÚLTIMO
+ * ponto de cada série é o estado com que comparar a coleta atual. É assim que o
+ * caminho sem servidor (GitHub Actions) obtém o `prev` que o Scheduler mantém em
+ * memória — o history versionado é a nossa memória entre execuções do cron.
+ */
+export function previousFromHistory(
+  history: HistoryFileDTO
+): Pick<ServiceStatusDTO, 'id' | 'uf' | 'document' | 'state' | 'cStat' | 'source'>[] {
+  const prev: Pick<
+    ServiceStatusDTO,
+    'id' | 'uf' | 'document' | 'state' | 'cStat' | 'source'
+  >[] = [];
+  for (const [id, points] of Object.entries(history.series)) {
+    const last = points[points.length - 1];
+    if (!last) continue;
+    // id é "Document:UF" (ex.: "NFe:SP"); document precisa casar o enum.
+    const [doc, uf] = id.split(':');
+    if (!doc || !uf || !(doc in DocumentType)) continue;
+    prev.push({
+      id,
+      uf,
+      document: DocumentType[doc as keyof typeof DocumentType],
+      state: last.state,
+      cStat: last.cStat,
+      source: last.source,
+    });
+  }
+  return prev;
+}
+
+/**
+ * Eventos SOURCE_DEGRADED para as fontes OFICIAIS que vieram degradadas nesta
+ * coleta (drift do portal). Emite por-coleta enquanto a fonte seguir degradada —
+ * o filtro NOTIFY_EVENTS e a natureza rara do drift evitam ruído; deduplicar para
+ * "só na transição" exigiria persistir o health anterior (melhoria futura).
+ */
+export function sourceDegradedEvents(
+  sources: SourceHealthDTO[] | undefined,
+  occurredAt: string
+): NotificationEventDTO[] {
+  if (!sources) return [];
+  return sources
+    .filter((s) => s.official && s.degraded)
+    .map((s) => ({
+      type: 'SOURCE_DEGRADED' as const,
+      source: s.source,
+      occurredAt,
+      payload: { coverage: s.coverage, collected: s.collected, expected: s.expected },
+    }));
+}
+
+/**
+ * Monta todos os eventos de notificação de uma coleta: transições de estado
+ * (serviço/contingência) via history + fontes oficiais degradadas.
+ */
+export function buildNotificationEvents(
+  history: HistoryFileDTO,
+  services: ServiceStatusDTO[],
+  sources: SourceHealthDTO[] | undefined,
+  occurredAt: string
+): NotificationEventDTO[] {
+  const transitions = detectTransitions(previousFromHistory(history), services, occurredAt);
+  return [...transitions, ...sourceDegradedEvents(sources, occurredAt)];
+}

--- a/apps/collector/src/technicalNotes.ts
+++ b/apps/collector/src/technicalNotes.ts
@@ -1,0 +1,56 @@
+import {
+  type NotificationEventDTO,
+  type TechnicalNoteDTO,
+  type TechnicalNotesFileDTO,
+} from '@monitor-sefaz/contracts';
+import type { TechnicalNote } from '@monitor-sefaz/core';
+
+/** Chave de identidade de uma NT (título + link) para dedup entre coletas. */
+function noteKey(n: { title: string; link: string | null }): string {
+  return `${n.title}|${n.link ?? ''}`;
+}
+
+/** Resultado do reconcile: arquivo atualizado + as NTs realmente novas. */
+export interface TechnicalNotesDiff {
+  readonly file: TechnicalNotesFileDTO;
+  readonly fresh: TechnicalNoteDTO[];
+}
+
+/**
+ * Reconcilia as notas raspadas com as já conhecidas: retorna o arquivo atualizado
+ * (conhecidas + novas, preservando o `firstSeenAt` das antigas) e a lista das NTs
+ * que são NOVAS nesta coleta — a base do evento TECHNICAL_NOTE. Função pura.
+ */
+export function reconcileTechnicalNotes(
+  known: TechnicalNotesFileDTO,
+  scraped: readonly TechnicalNote[],
+  now: string
+): TechnicalNotesDiff {
+  const knownByKey = new Map(known.notes.map((n) => [noteKey(n), n]));
+  const fresh: TechnicalNoteDTO[] = [];
+
+  for (const s of scraped) {
+    if (!knownByKey.has(noteKey(s))) {
+      const dto: TechnicalNoteDTO = { title: s.title, link: s.link, firstSeenAt: now };
+      knownByKey.set(noteKey(s), dto);
+      fresh.push(dto);
+    }
+  }
+
+  return {
+    file: { updatedAt: now, notes: [...knownByKey.values()] },
+    fresh,
+  };
+}
+
+/** Traduz as NTs novas em eventos de notificação TECHNICAL_NOTE. */
+export function technicalNoteEvents(
+  fresh: readonly TechnicalNoteDTO[],
+  occurredAt: string
+): NotificationEventDTO[] {
+  return fresh.map((n) => ({
+    type: 'TECHNICAL_NOTE' as const,
+    occurredAt,
+    payload: { title: n.title, link: n.link },
+  }));
+}

--- a/apps/collector/test/digest.test.ts
+++ b/apps/collector/test/digest.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import type { SummaryDTO } from '@monitor-sefaz/contracts';
+import { buildDigestEvent, parseDigestHour } from '../src/digest.js';
+
+const summary: SummaryDTO = {
+  environment: 'production',
+  generatedAt: '2026-07-10T08:00:00.000Z',
+  total: 135,
+  operational: 130,
+  failing: 5,
+  availability: 96.3,
+  avgLatencyMs: 200,
+  byDocument: [],
+  byAuthorizer: [],
+  sources: [
+    { source: 'svrs', official: true, collected: 112, expected: 135, coverage: 0.83, degraded: false },
+    { source: 'availability', official: true, collected: 0, expected: 135, coverage: 0, degraded: true },
+  ],
+};
+
+describe('parseDigestHour', () => {
+  it('aceita 0–23; rejeita vazio, fora do range e não-inteiro', () => {
+    expect(parseDigestHour('8')).toBe(8);
+    expect(parseDigestHour('0')).toBe(0);
+    expect(parseDigestHour('23')).toBe(23);
+    expect(parseDigestHour(undefined)).toBeNull();
+    expect(parseDigestHour('')).toBeNull();
+    expect(parseDigestHour('24')).toBeNull();
+    expect(parseDigestHour('-1')).toBeNull();
+    expect(parseDigestHour('8.5')).toBeNull();
+    expect(parseDigestHour('abc')).toBeNull();
+  });
+});
+
+describe('buildDigestEvent', () => {
+  it('emite DAILY_DIGEST quando a hora UTC bate a hora-alvo', () => {
+    const ev = buildDigestEvent(summary, 8, new Date('2026-07-10T08:17:00.000Z'));
+    expect(ev).not.toBeNull();
+    expect(ev!.type).toBe('DAILY_DIGEST');
+    expect(ev!.payload).toMatchObject({
+      total: 135,
+      operational: 130,
+      failing: 5,
+      availability: 96.3,
+      degradedSources: ['availability'],
+    });
+  });
+
+  it('não emite fora da hora-alvo', () => {
+    expect(buildDigestEvent(summary, 8, new Date('2026-07-10T09:00:00.000Z'))).toBeNull();
+  });
+
+  it('não emite quando desligado (targetHour null)', () => {
+    expect(buildDigestEvent(summary, null, new Date('2026-07-10T08:00:00.000Z'))).toBeNull();
+  });
+
+  it('degradedSources vazio quando não há sources ou nenhuma degradada', () => {
+    const clean = { ...summary, sources: undefined };
+    const ev = buildDigestEvent(clean, 8, new Date('2026-07-10T08:00:00.000Z'));
+    expect(ev!.payload!.degradedSources).toEqual([]);
+  });
+});

--- a/apps/collector/test/notifyEvents.test.ts
+++ b/apps/collector/test/notifyEvents.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DocumentType,
+  type HistoryFileDTO,
+  type ServiceStatusDTO,
+  type SourceHealthDTO,
+} from '@monitor-sefaz/contracts';
+import {
+  previousFromHistory,
+  sourceDegradedEvents,
+  buildNotificationEvents,
+} from '../src/notifyEvents.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+
+function history(series: Record<string, string[]>): HistoryFileDTO {
+  const out: HistoryFileDTO = { updatedAt: AT, series: {} };
+  for (const [id, states] of Object.entries(series)) {
+    out.series[id] = states.map((state, i) => ({
+      timestamp: `2026-07-09T0${i}:00:00.000Z`,
+      state: state as never,
+      cStat: null,
+      latencyMs: 0,
+      source: 'svrs',
+    }));
+  }
+  return out;
+}
+
+function svc(id: string, state: ServiceStatusDTO['state']): ServiceStatusDTO {
+  const [document, uf] = id.split(':');
+  return {
+    id,
+    document: DocumentType[document as keyof typeof DocumentType],
+    uf: uf!,
+    authorizer: uf!,
+    environment: 'production',
+    state,
+    cStat: null,
+    xMotivo: null,
+    latencyMs: 0,
+    source: 'svrs',
+    error: null,
+    checkedAt: AT,
+  };
+}
+
+describe('previousFromHistory', () => {
+  it('usa o ÚLTIMO ponto de cada série como estado anterior', () => {
+    const prev = previousFromHistory(history({ 'NFe:SP': ['OPERATIONAL', 'DOWN'] }));
+    expect(prev).toHaveLength(1);
+    expect(prev[0]).toMatchObject({ id: 'NFe:SP', uf: 'SP', document: DocumentType.NFe, state: 'DOWN' });
+  });
+
+  it('ignora ids malformados ou sem pontos', () => {
+    const h: HistoryFileDTO = {
+      updatedAt: AT,
+      series: { 'lixo-sem-dois-pontos': [], 'XXe:SP': [] },
+    };
+    expect(previousFromHistory(h)).toEqual([]);
+  });
+});
+
+describe('sourceDegradedEvents', () => {
+  const src = (source: string, official: boolean, degraded: boolean): SourceHealthDTO => ({
+    source: source as never,
+    official,
+    collected: degraded ? 0 : 100,
+    expected: 135,
+    coverage: degraded ? 0 : 0.74,
+    degraded,
+  });
+
+  it('emite só para fontes OFICIAIS degradadas', () => {
+    const events = sourceDegradedEvents(
+      [src('svrs', true, false), src('availability', true, true), src('integranotas', false, true)],
+      AT
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({ type: 'SOURCE_DEGRADED', source: 'availability' });
+  });
+
+  it('sem sources retorna vazio', () => {
+    expect(sourceDegradedEvents(undefined, AT)).toEqual([]);
+  });
+});
+
+describe('buildNotificationEvents', () => {
+  it('combina transições de estado e fontes degradadas', () => {
+    const h = history({ 'NFe:SP': ['OPERATIONAL'], 'NFe:RJ': ['OPERATIONAL'] });
+    const services = [svc('NFe:SP', 'DOWN'), svc('NFe:RJ', 'OPERATIONAL')];
+    const sources: SourceHealthDTO[] = [
+      { source: 'availability', official: true, collected: 0, expected: 135, coverage: 0, degraded: true },
+    ];
+    const events = buildNotificationEvents(h, services, sources, AT);
+    const types = events.map((e) => e.type);
+    expect(types).toContain('SERVICE_DOWN'); // SP: OPERATIONAL → DOWN
+    expect(types).toContain('SOURCE_DEGRADED'); // availability degradada
+    expect(types).not.toContain('SERVICE_RECOVERED'); // RJ não mudou
+  });
+
+  it('primeira coleta (history vazio) não gera transições', () => {
+    const events = buildNotificationEvents(
+      { updatedAt: AT, series: {} },
+      [svc('NFe:SP', 'DOWN')],
+      undefined,
+      AT
+    );
+    expect(events).toEqual([]); // baseline
+  });
+});

--- a/apps/collector/test/technicalNotes.test.ts
+++ b/apps/collector/test/technicalNotes.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import type { TechnicalNotesFileDTO } from '@monitor-sefaz/contracts';
+import type { TechnicalNote } from '@monitor-sefaz/core';
+import { reconcileTechnicalNotes, technicalNoteEvents } from '../src/technicalNotes.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+const LATER = '2026-07-11T00:00:00.000Z';
+
+const note = (title: string, link: string | null = null): TechnicalNote => ({ title, link });
+
+describe('reconcileTechnicalNotes', () => {
+  it('primeira coleta: todas as notas são novas', () => {
+    const empty: TechnicalNotesFileDTO = { updatedAt: AT, notes: [] };
+    const { file, fresh } = reconcileTechnicalNotes(empty, [note('NT-1'), note('NT-2')], AT);
+    expect(fresh).toHaveLength(2);
+    expect(file.notes).toHaveLength(2);
+    expect(file.notes[0]!.firstSeenAt).toBe(AT);
+  });
+
+  it('coleta seguinte: só a NT inédita é nova, e preserva firstSeenAt das antigas', () => {
+    const known: TechnicalNotesFileDTO = {
+      updatedAt: AT,
+      notes: [{ title: 'NT-1', link: null, firstSeenAt: AT }],
+    };
+    const { file, fresh } = reconcileTechnicalNotes(known, [note('NT-1'), note('NT-2')], LATER);
+    expect(fresh.map((n) => n.title)).toEqual(['NT-2']);
+    expect(file.notes).toHaveLength(2);
+    // a NT-1 mantém o firstSeenAt original
+    expect(file.notes.find((n) => n.title === 'NT-1')!.firstSeenAt).toBe(AT);
+    expect(file.notes.find((n) => n.title === 'NT-2')!.firstSeenAt).toBe(LATER);
+  });
+
+  it('distingue notas de mesmo título mas link diferente', () => {
+    const known: TechnicalNotesFileDTO = {
+      updatedAt: AT,
+      notes: [{ title: 'NT', link: 'a', firstSeenAt: AT }],
+    };
+    const { fresh } = reconcileTechnicalNotes(known, [note('NT', 'a'), note('NT', 'b')], LATER);
+    expect(fresh).toHaveLength(1);
+    expect(fresh[0]!.link).toBe('b');
+  });
+
+  it('nenhuma NT nova quando nada mudou', () => {
+    const known: TechnicalNotesFileDTO = {
+      updatedAt: AT,
+      notes: [{ title: 'NT-1', link: null, firstSeenAt: AT }],
+    };
+    const { fresh } = reconcileTechnicalNotes(known, [note('NT-1')], LATER);
+    expect(fresh).toEqual([]);
+  });
+});
+
+describe('technicalNoteEvents', () => {
+  it('gera um evento TECHNICAL_NOTE por NT nova com título/link no payload', () => {
+    const events = technicalNoteEvents(
+      [{ title: 'NT-9', link: 'http://x', firstSeenAt: AT }],
+      AT
+    );
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      type: 'TECHNICAL_NOTE',
+      occurredAt: AT,
+      payload: { title: 'NT-9', link: 'http://x' },
+    });
+  });
+});

--- a/apps/collector/tsconfig.json
+++ b/apps/collector/tsconfig.json
@@ -9,6 +9,7 @@
   "references": [
     { "path": "../../packages/catalog" },
     { "path": "../../packages/core" },
-    { "path": "../../packages/contracts" }
+    { "path": "../../packages/contracts" },
+    { "path": "../../packages/notifier" }
   ]
 }

--- a/apps/collector/vitest.config.ts
+++ b/apps/collector/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/apps/worker/src/WorkerAvailabilityProvider.ts
+++ b/apps/worker/src/WorkerAvailabilityProvider.ts
@@ -1,7 +1,10 @@
 import {
   AvailabilityParser,
   AVAILABILITY_URLS,
+  backoffMs,
+  defaultSleeper,
   type AvailabilityRow,
+  type Sleeper,
 } from '@monitor-sefaz/core';
 import { DocumentType } from '@monitor-sefaz/catalog';
 
@@ -18,6 +21,13 @@ const BROWSER_UA =
  * que funciona em Workers).
  */
 export class WorkerAvailabilityProvider {
+  constructor(
+    /** Sleeper do backoff entre tentativas; injetável para os testes não dormirem. */
+    private readonly sleep: Sleeper = defaultSleeper,
+    /** Fonte de aleatoriedade do jitter; injetável para o backoff ser determinístico. */
+    private readonly random: () => number = Math.random
+  ) {}
+
   public supportedDocuments(): DocumentType[] {
     return Object.keys(AVAILABILITY_URLS) as DocumentType[];
   }
@@ -33,25 +43,39 @@ export class WorkerAvailabilityProvider {
     // (página sem a tabela) de forma intermitente. NÃO há fallback de
     // homologação: o ambiente é distinto e reportaria status errado.
     let lastError: unknown;
+    const totalAttempts = urls.length * attemptsPerUrl;
+    let attemptIndex = 0;
     for (const url of urls) {
       for (let attempt = 1; attempt <= attemptsPerUrl; attempt += 1) {
+        attemptIndex += 1;
         try {
-          const rows = await this.fetchOne(url, parser);
-          if (rows.length > 0) {
+          const { rows, headerMatched } = await this.fetchOne(url, parser);
+          // Paridade com o Node: só confia nas linhas se o cabeçalho validou o
+          // layout. Sem isso, esvazia a fonte (→ degraded no consenso) em vez de
+          // publicar leitura de colunas possivelmente erradas.
+          if (rows.length > 0 && headerMatched) {
             return rows;
           }
+          lastError = new Error(
+            headerMatched ? 'resposta sem linhas de status' : 'layout inesperado: cabeçalho não reconhecido'
+          );
         } catch (err) {
           lastError = err;
         }
+        // Backoff antes da PRÓXIMA tentativa (paridade com o caminho Node): dá
+        // tempo de uma falha transitória passar e não martela a SEFAZ.
+        if (attemptIndex < totalAttempts) {
+          await this.sleep(backoffMs(attempt, this.random));
+        }
       }
     }
-    if (lastError) {
-      throw lastError instanceof Error ? lastError : new Error(String(lastError));
-    }
-    return [];
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
   }
 
-  private async fetchOne(url: string, parser: AvailabilityParser): Promise<AvailabilityRow[]> {
+  private async fetchOne(
+    url: string,
+    parser: AvailabilityParser
+  ): Promise<{ rows: AvailabilityRow[]; headerMatched: boolean }> {
     const headers: Record<string, string> = {
       'User-Agent': BROWSER_UA,
       Accept: 'text/html,application/xhtml+xml',
@@ -75,8 +99,11 @@ export class WorkerAvailabilityProvider {
       }
     }
 
-    const html = await response.text();
-    return parser.parse(html);
+    // A página é latin-1; o Worker não tem Buffer. Decodificamos via TextDecoder
+    // (paridade com o caminho Node, que faz `Buffer.toString('latin1')`, e com o
+    // fetcher SVRS do Worker). Usar `.text()` assumiria UTF-8 e corromperia acentos.
+    const html = new TextDecoder('latin1').decode(await response.arrayBuffer());
+    return parser.parseWithDiagnostics(html);
   }
 
   /**

--- a/apps/worker/test/WorkerAvailabilityProvider.test.ts
+++ b/apps/worker/test/WorkerAvailabilityProvider.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { DocumentType } from '@monitor-sefaz/catalog';
+import { AvailabilityParser } from '@monitor-sefaz/core';
+import { WorkerAvailabilityProvider } from '../src/WorkerAvailabilityProvider.js';
+
+// A fixture é a página REAL da Receita, salva em latin-1 (mesma usada nos testes
+// do core). Reaproveitamos o caminho do fixture do pacote core.
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(
+  here,
+  '..',
+  '..',
+  '..',
+  'packages',
+  'core',
+  'test',
+  'fixtures',
+  'availability',
+  'nfe-disponibilidade.html'
+);
+// Bytes crus latin-1 (não decodificados) — é isso que a rede entrega.
+const fixtureLatin1Bytes = readFileSync(fixturePath, 'latin1');
+
+const realFetch = globalThis.fetch;
+afterEach(() => {
+  globalThis.fetch = realFetch;
+});
+
+/** Response falso servindo os bytes latin-1 da fixture (sem redirect). */
+function latin1Response(): Response {
+  // Recria o array de bytes a partir da string latin-1 (1 char = 1 byte).
+  const bytes = Uint8Array.from(fixtureLatin1Bytes, (c) => c.charCodeAt(0));
+  return new Response(bytes, { status: 200 });
+}
+
+describe('WorkerAvailabilityProvider — paridade com o caminho Node', () => {
+  it('decodifica latin-1 e produz o MESMO resultado que o parser do core', async () => {
+    globalThis.fetch = (async () => latin1Response()) as typeof fetch;
+
+    const provider = new WorkerAvailabilityProvider();
+    const workerRows = await provider.fetch(DocumentType.NFe);
+
+    // Referência: o parser do core sobre a MESMA fixture decodificada como latin-1
+    // (é como o collector Node faz via Buffer.toString('latin1')).
+    const expected = new AvailabilityParser(DocumentType.NFe).parse(fixtureLatin1Bytes);
+
+    expect(workerRows.length).toBeGreaterThan(0);
+    expect(workerRows).toEqual(expected);
+  });
+
+  it('faz backoff entre tentativas e tem sucesso após falha transitória', async () => {
+    let calls = 0;
+    globalThis.fetch = (async () => {
+      calls += 1;
+      if (calls === 1) throw new Error('conexão recusada (transitória)');
+      return latin1Response();
+    }) as typeof fetch;
+
+    const delays: number[] = [];
+    const provider = new WorkerAvailabilityProvider(
+      async (ms) => {
+        delays.push(ms);
+      },
+      () => 0.5 // jitter neutro → backoff = 500 × attempt
+    );
+    const rows = await provider.fetch(DocumentType.NFe);
+
+    expect(calls).toBe(2);
+    expect(rows.length).toBeGreaterThan(0);
+    expect(delays).toEqual([500]); // um backoff entre a 1ª e a 2ª tentativa
+  });
+
+  it('esvazia a fonte quando o layout muda (cabeçalho irreconhecível), mesmo com linhas', async () => {
+    // Página com linhas de dados plausíveis, mas SEM um cabeçalho que casa
+    // "status"/"tempo" → drift. Confiar nessas linhas leria colunas erradas; o
+    // provider trata como falha (esvazia → degraded no consenso) em vez de publicar.
+    const driftHtml = `<table>
+      <tr><th>Coluna A</th><th>Coluna B</th><th>Coluna C</th><th>Coluna D</th>
+          <th>Coluna E</th><th>Coluna F</th></tr>
+      <tr><td>SP</td><td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+          <td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+          <td><img src="bola_verde.png"></td></tr>
+    </table>`;
+    const bytes = Uint8Array.from(driftHtml, (c) => c.charCodeAt(0));
+    globalThis.fetch = (async () => new Response(bytes, { status: 200 })) as typeof fetch;
+
+    const provider = new WorkerAvailabilityProvider(async () => {}, () => 0.5);
+    // Sem cabeçalho reconhecível em nenhuma tentativa → lança (fonte vazia).
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/layout inesperado/);
+  });
+});

--- a/apps/worker/vitest.config.ts
+++ b/apps/worker/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -135,6 +135,51 @@ export const summarySchema = z.object({
 });
 export type SummaryDTO = z.infer<typeof summarySchema>;
 
+/**
+ * Tipos de evento de notificação. Cada transição de estado relevante ou sinal
+ * operacional vira um destes; os canais (Discord/Slack/...) formatam por tipo.
+ * - SERVICE_DOWN/RECOVERED: serviço saiu/voltou ao ar (via `isUp`).
+ * - CONTINGENCY_ENTERED/EXITED: entrou/saiu de contingência (SVC). Independente
+ *   de DOWN/RECOVERED — contingência conta como "no ar", então os dois podem
+ *   coexistir numa mesma coleta.
+ * - TECHNICAL_NOTE: nova Nota Técnica publicada (Fase 6).
+ * - SOURCE_DEGRADED: uma fonte oficial ficou degradada (sinal de drift, Fase 8).
+ * - DAILY_DIGEST: resumo periódico de saúde (Fase 7).
+ */
+export const notificationEventTypeSchema = z.enum([
+  'SERVICE_DOWN',
+  'SERVICE_RECOVERED',
+  'CONTINGENCY_ENTERED',
+  'CONTINGENCY_EXITED',
+  'TECHNICAL_NOTE',
+  'SOURCE_DEGRADED',
+  'DAILY_DIGEST',
+]);
+export type NotificationEventType = z.infer<typeof notificationEventTypeSchema>;
+
+/**
+ * Um evento de notificação. Campos específicos são opcionais porque variam por
+ * tipo: transições de serviço preenchem serviceId/uf/document/estados; um digest
+ * ou uma nota técnica usam `payload` livre.
+ */
+export const notificationEventSchema = z.object({
+  type: notificationEventTypeSchema,
+  /** `{document}:{uf}` quando o evento é de um serviço específico. */
+  serviceId: z.string().optional(),
+  uf: z.string().optional(),
+  document: documentTypeSchema.optional(),
+  previousState: serviceStateSchema.optional(),
+  currentState: serviceStateSchema.optional(),
+  cStat: z.number().nullable().optional(),
+  /** Fonte associada (ex.: qual fonte degradou em SOURCE_DEGRADED). */
+  source: statusSourceSchema.optional(),
+  /** ISO 8601 — quando o evento foi detectado. */
+  occurredAt: z.string(),
+  /** Dados livres por tipo (ex.: título/link de NT, números do digest). */
+  payload: z.record(z.unknown()).optional(),
+});
+export type NotificationEventDTO = z.infer<typeof notificationEventSchema>;
+
 /** Períodos suportados pela consulta de histórico curto. */
 // '1h'/'6h' foram removidos: com a cadência real de coleta (~3h/ponto) rendem
 // 0–2 amostras, deixando gráfico vazio e uptime sobre amostra única.

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -97,6 +97,26 @@ export const summaryGroupSchema = z.object({
   availability: z.number(),
 });
 
+/**
+ * Saúde de UMA fonte na última coleta. `degraded` sinaliza DRIFT: uma fonte que
+ * normalmente cobre a maior parte do catálogo veio muito abaixo do piso — indício
+ * de que o portal mudou o HTML e o parser parou de casar, em vez de uma queda real
+ * da SEFAZ (que retornaria os serviços com estado DOWN/ERROR, não ausentes).
+ */
+export const sourceHealthSchema = z.object({
+  source: statusSourceSchema,
+  official: z.boolean(),
+  /** Serviços que a fonte devolveu nesta coleta. */
+  collected: z.number(),
+  /** Total de serviços do catálogo (referência de cobertura). */
+  expected: z.number(),
+  /** collected / expected, 0..1, arredondado a 3 casas. */
+  coverage: z.number(),
+  /** coverage abaixo do piso → provável drift do portal. */
+  degraded: z.boolean(),
+});
+export type SourceHealthDTO = z.infer<typeof sourceHealthSchema>;
+
 export const summarySchema = z.object({
   environment: environmentSchema,
   generatedAt: z.string(),
@@ -107,6 +127,11 @@ export const summarySchema = z.object({
   avgLatencyMs: z.number().nullable(),
   byDocument: z.array(summaryGroupSchema),
   byAuthorizer: z.array(summaryGroupSchema),
+  /**
+   * Diagnóstico por fonte da última coleta (opcional para retrocompat com
+   * summaries antigos que não o traziam). Base do sinal de drift.
+   */
+  sources: z.array(sourceHealthSchema).optional(),
 });
 export type SummaryDTO = z.infer<typeof summarySchema>;
 

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -180,6 +180,22 @@ export const notificationEventSchema = z.object({
 });
 export type NotificationEventDTO = z.infer<typeof notificationEventSchema>;
 
+/** Uma Nota Técnica conhecida (persistida para dedup entre coletas). */
+export const technicalNoteSchema = z.object({
+  title: z.string(),
+  link: z.string().nullable(),
+  /** ISO 8601 — quando o monitor viu esta NT pela primeira vez. */
+  firstSeenAt: z.string(),
+});
+export type TechnicalNoteDTO = z.infer<typeof technicalNoteSchema>;
+
+/** Arquivo versionado com as NTs já vistas (fonte da dedup). */
+export const technicalNotesFileSchema = z.object({
+  updatedAt: z.string(),
+  notes: z.array(technicalNoteSchema),
+});
+export type TechnicalNotesFileDTO = z.infer<typeof technicalNotesFileSchema>;
+
 /** Períodos suportados pela consulta de histórico curto. */
 // '1h'/'6h' foram removidos: com a cadência real de coleta (~3h/ponto) rendem
 // 0–2 amostras, deixando gráfico vazio e uptime sobre amostra única.

--- a/packages/core/src/availability/AvailabilityParser.ts
+++ b/packages/core/src/availability/AvailabilityParser.ts
@@ -11,6 +11,17 @@ export interface AvailabilityRow {
 }
 
 /**
+ * Resultado do parse com diagnóstico de layout. `headerMatched` indica se a coluna
+ * de status foi resolvida pelo TEXTO do cabeçalho (robusto a mudança de layout) ou
+ * se caímos no índice fixo — um `false` com página não-vazia é indício de DRIFT do
+ * HTML da SEFAZ, sinal que o consenso pode transformar em alerta.
+ */
+export interface AvailabilityParseResult {
+  readonly rows: AvailabilityRow[];
+  readonly headerMatched: boolean;
+}
+
+/**
  * Layout de colunas da tabela de disponibilidade — VARIA por documento.
  * `statusIndex` é a coluna "Status Serviço"; `tMedIndex` é a coluna "Tempo Médio".
  *
@@ -41,6 +52,37 @@ function colorToState(src: string): ServiceState | null {
   if (src.includes('bola_amarela')) return ServiceState.SlowDown;
   if (src.includes('bola_vermelh')) return ServiceState.Down;
   return null;
+}
+
+/** Normaliza texto de cabeçalho: minúsculo, sem acento e sem não-letras. */
+function normalizeHeader(raw: string): string {
+  return raw
+    .toLowerCase()
+    .normalize('NFD')
+    .replace(/[̀-ͯ]/g, '') // remove diacríticos
+    .replace(/[^a-z]/g, ''); // "Status Serviço4" → "statusservico"
+}
+
+/**
+ * Descobre os índices das colunas "Status Serviço" e "Tempo Médio" pelo TEXTO do
+ * cabeçalho (`<th>`), tolerante a inserção/remoção de colunas pela SEFAZ. Retorna
+ * `null` quando o cabeçalho não casa (aí o chamador usa o índice fixo como
+ * fallback e sinaliza que o layout pode ter mudado).
+ */
+function findColumnsByHeader(
+  headerCells: string[]
+): { statusIndex: number; tMedIndex: number } | null {
+  const norm = headerCells.map(normalizeHeader);
+  // Casa por âncoras ASCII estáveis ("status", "tempo") em vez do texto completo:
+  // a página vem em latin-1 e "Serviço"/"Médio" chegam como mojibake ("serviao"),
+  // mas "Status" e "Tempo" não têm acento e sobrevivem à decodificação.
+  const statusIndex = norm.findIndex((h) => h.includes('status'));
+  const tMedIndex = norm.findIndex((h) => h.includes('tempo'));
+  if (statusIndex < 0) {
+    return null; // sem a coluna-chave, não confiamos no cabeçalho
+  }
+  // tMed pode não existir em alguns layouts; -1 é aceitável (vira null no parse).
+  return { statusIndex, tMedIndex };
 }
 
 function normalizeAuthorizer(raw: string): AuthorizerCode {
@@ -75,9 +117,33 @@ export class AvailabilityParser {
   }
 
   public parse(html: string): AvailabilityRow[] {
+    return this.parseWithDiagnostics(html).rows;
+  }
+
+  /**
+   * Como `parse`, mas informa se a coluna de status foi resolvida pelo cabeçalho
+   * (`headerMatched: true`) ou pelo índice fixo de fallback. Prefere SEMPRE o
+   * cabeçalho — casar "Status Serviço"/"Tempo Médio" pelo texto sobrevive à
+   * SEFAZ inserir/remover colunas; o índice fixo só entra quando o cabeçalho não
+   * casa, e nesse caso `headerMatched: false` sinaliza possível drift.
+   */
+  public parseWithDiagnostics(html: string): AvailabilityParseResult {
     const $ = cheerio.load(html);
+
+    // Tenta resolver as colunas pelo cabeçalho da PRIMEIRA linha que tem <th>.
+    let resolved: { statusIndex: number; tMedIndex: number } | null = null;
+    $('tr').each((_, tr) => {
+      if (resolved) return;
+      const ths = $(tr).find('th');
+      if (ths.length > 2) {
+        const headers = ths.map((_i, th) => $(th).text()).get();
+        resolved = findColumnsByHeader(headers);
+      }
+    });
+
+    const headerMatched = resolved !== null;
+    const { statusIndex, tMedIndex } = resolved ?? this.layout;
     const rows: AvailabilityRow[] = [];
-    const { statusIndex, tMedIndex } = this.layout;
 
     $('tr').each((_, tr) => {
       const cells = $(tr).find('td');
@@ -96,7 +162,9 @@ export class AvailabilityParser {
         return; // coluna sem bolinha de status → não é uma linha de dados
       }
 
-      const tMedText = cells.eq(tMedIndex).text().trim();
+      // tMedIndex pode ser -1 (cabeçalho sem "Tempo Médio"): eq(-1) não casa,
+      // texto vazio → tMedSeconds null. Comportamento correto, sem exceção.
+      const tMedText = tMedIndex >= 0 ? cells.eq(tMedIndex).text().trim() : '';
       const tMedMatch = tMedText.match(/\d+/);
 
       rows.push({
@@ -106,6 +174,6 @@ export class AvailabilityParser {
       });
     });
 
-    return rows;
+    return { rows, headerMatched };
   }
 }

--- a/packages/core/src/availability/AvailabilityProvider.ts
+++ b/packages/core/src/availability/AvailabilityProvider.ts
@@ -2,7 +2,12 @@ import axios, { type AxiosInstance } from 'axios';
 import { wrapper } from 'axios-cookiejar-support';
 import { CookieJar } from 'tough-cookie';
 import { DocumentType } from '@monitor-sefaz/catalog';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 import { AvailabilityParser, type AvailabilityRow } from './AvailabilityParser.js';
+
+// Reexporta o backoff/Sleeper compartilhado para não quebrar importações antigas
+// que apontam para este módulo (ex.: SvrsProvider e os testes).
+export { backoffMs, type Sleeper };
 
 /**
  * URLs das páginas oficiais de disponibilidade de PRODUÇÃO, por documento, em
@@ -32,19 +37,6 @@ const BROWSER_UA =
  * loop de redirect sem cookies; por isso usamos um cookie jar e um User-Agent
  * de browser. Esta é a mesma estratégia de monitores públicos da SEFAZ.
  */
-/** Espera `ms` antes de resolver. Injetável para os testes não dormirem de verdade. */
-export type Sleeper = (ms: number) => Promise<void>;
-const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
-
-/**
- * Atraso (ms) antes da próxima tentativa: linear (500ms × tentativa) com jitter
- * de ±20%. `attempt` é 1-based; `random` deve devolver [0,1). Função pura para
- * ser testável de forma determinística.
- */
-export function backoffMs(attempt: number, random: () => number = Math.random): number {
-  return Math.round(500 * attempt * (0.8 + random() * 0.4));
-}
-
 export class HttpAvailabilityProvider {
   private readonly http: AxiosInstance;
 
@@ -103,11 +95,20 @@ export class HttpAvailabilityProvider {
         try {
           const response = await this.http.get<ArrayBuffer>(url);
           const html = Buffer.from(response.data).toString('latin1');
-          const rows = parser.parse(html);
-          if (rows.length > 0) {
+          const { rows, headerMatched } = parser.parseWithDiagnostics(html);
+          // Só confiamos nas linhas se o layout foi VALIDADO pelo cabeçalho. Se o
+          // cabeçalho não casou (headerMatched=false), o HTML pode ter mudado e as
+          // linhas viriam de colunas erradas — tratamos como falha de parse, que
+          // esvazia esta fonte e a marca `degraded` no consenso (sinal de drift),
+          // em vez de publicar dado possivelmente incorreto em silêncio.
+          if (rows.length > 0 && headerMatched) {
             return rows;
           }
-          lastError = new Error(`resposta sem linhas de status (HTTP ${response.status})`);
+          lastError = new Error(
+            headerMatched
+              ? `resposta sem linhas de status (HTTP ${response.status})`
+              : `layout inesperado: cabeçalho não reconhecido (HTTP ${response.status})`
+          );
         } catch (err) {
           lastError = err;
         }

--- a/packages/core/src/consensus/ConsensusCollector.ts
+++ b/packages/core/src/consensus/ConsensusCollector.ts
@@ -1,4 +1,4 @@
-import { Catalog } from '@monitor-sefaz/catalog';
+import { Catalog, Environment, DEFAULT_MIN_COVERAGE_RATIO } from '@monitor-sefaz/catalog';
 import {
   AvailabilityCollector,
   type CollectedStatus,
@@ -21,6 +21,28 @@ export interface ConsensusSource {
 }
 
 /**
+ * Saúde de uma fonte numa coleta — quanto do catálogo ela cobriu e se está
+ * `degraded` (indício de drift do portal). `expected` é o total do catálogo, não
+ * a cobertura teórica exata da fonte: o sinal que importa é uma fonte que costuma
+ * trazer a maior parte dos serviços despencar para quase nada (parser parou de
+ * casar após mudança de HTML), não medir sua fração ideal ao decimal.
+ */
+export interface SourceHealth {
+  readonly source: string;
+  readonly official: boolean;
+  readonly collected: number;
+  readonly expected: number;
+  readonly coverage: number;
+  readonly degraded: boolean;
+}
+
+/** Resultado do consenso com o diagnóstico por fonte anexado. */
+export interface ConsensusResult {
+  readonly services: CollectedStatus[];
+  readonly sources: SourceHealth[];
+}
+
+/**
  * Coletor MULTI-FONTE com PRECEDÊNCIA OFICIAL.
  *
  * Substitui o `HybridCollector` (que era failover A→B) por um cruzamento real:
@@ -39,7 +61,12 @@ export interface ConsensusSource {
 export class ConsensusCollector implements StatusCollectorLike {
   public readonly name = 'consensus';
 
-  constructor(private readonly sources: ConsensusSource[]) {}
+  constructor(
+    private readonly sources: ConsensusSource[],
+    private readonly catalog = new Catalog(),
+    /** Piso de cobertura por fonte abaixo do qual ela é marcada `degraded`. */
+    private readonly minCoverageRatio = DEFAULT_MIN_COVERAGE_RATIO
+  ) {}
 
   /**
    * Consenso padrão para Node, em ordem de precedência:
@@ -47,31 +74,59 @@ export class ConsensusCollector implements StatusCollectorLike {
    * mais completo). Mesmo motor para api, collector (Actions) e — quando portado —
    * o Worker.
    */
-  public static createForNode(catalog = new Catalog()): ConsensusCollector {
-    return new ConsensusCollector([
-      {
-        name: 'svrs',
-        official: true,
-        collector: new SvrsCollector(new SvrsProvider(createHttpSvrsFetcher()), catalog),
-      },
-      {
-        name: 'availability',
-        official: true,
-        collector: new AvailabilityCollector(new HttpAvailabilityProvider(), catalog),
-      },
-      {
-        name: 'integranotas',
-        official: false,
-        collector: IntegraNotasCollector.create(createHttpIntegraNotasFetcher(), catalog),
-      },
-    ]);
+  public static createForNode(
+    catalog = new Catalog(),
+    minCoverageRatio = DEFAULT_MIN_COVERAGE_RATIO
+  ): ConsensusCollector {
+    return new ConsensusCollector(
+      [
+        {
+          name: 'svrs',
+          official: true,
+          collector: new SvrsCollector(new SvrsProvider(createHttpSvrsFetcher()), catalog),
+        },
+        {
+          name: 'availability',
+          official: true,
+          collector: new AvailabilityCollector(new HttpAvailabilityProvider(), catalog),
+        },
+        {
+          name: 'integranotas',
+          official: false,
+          collector: IntegraNotasCollector.create(createHttpIntegraNotasFetcher(), catalog),
+        },
+      ],
+      catalog,
+      minCoverageRatio
+    );
   }
 
   public async collect(): Promise<CollectedStatus[]> {
+    const { services } = await this.collectWithDiagnostics();
+    return services;
+  }
+
+  /**
+   * Como `collect()`, mas também devolve a saúde por fonte (cobertura + `degraded`)
+   * — o sinal de drift do portal. A API/worker/collector usam `collect()`; quem
+   * quer o diagnóstico (o `summary.json`) chama este método.
+   */
+  public async collectWithDiagnostics(): Promise<ConsensusResult> {
     const settled = await Promise.allSettled(this.sources.map((s) => s.collector.collect()));
     const results = settled.map((r, i) => ({
       source: this.sources[i]!,
       statuses: r.status === 'fulfilled' ? r.value : [],
+    }));
+
+    const expected = this.catalog.listAll(Environment.Production).length;
+    const floor = Math.floor(expected * this.minCoverageRatio);
+    const sourceHealth: SourceHealth[] = results.map(({ source, statuses }) => ({
+      source: source.name,
+      official: source.official,
+      collected: statuses.length,
+      expected,
+      coverage: expected === 0 ? 0 : Number((statuses.length / expected).toFixed(3)),
+      degraded: statuses.length < floor,
     }));
 
     const key = (s: CollectedStatus): string => `${s.document}:${s.uf}`;
@@ -106,6 +161,6 @@ export class ConsensusCollector implements StatusCollectorLike {
       }
     }
 
-    return [...winners.values()];
+    return { services: [...winners.values()], sources: sourceHealth };
   }
 }

--- a/packages/core/src/domain/retry.ts
+++ b/packages/core/src/domain/retry.ts
@@ -1,0 +1,22 @@
+/**
+ * Utilitários de retry/backoff compartilhados pelas fontes ao vivo (Availability,
+ * SVRS e IntegraNotas). Ficam no domínio — e não em uma fonte específica — porque
+ * os três providers seguem a MESMA política: algumas tentativas com backoff linear
+ * e jitter, já que os portais da SEFAZ e a API do IntegraNotas ocasionalmente
+ * recusam a conexão ou devolvem uma resposta vazia de forma transitória.
+ */
+
+/** Espera `ms` antes de resolver. Injetável para os testes não dormirem de verdade. */
+export type Sleeper = (ms: number) => Promise<void>;
+
+/** Sleeper padrão baseado em `setTimeout`. */
+export const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Atraso (ms) antes da próxima tentativa: linear (500ms × tentativa) com jitter
+ * de ±20%. `attempt` é 1-based; `random` deve devolver [0,1). Função pura para
+ * ser testável de forma determinística.
+ */
+export function backoffMs(attempt: number, random: () => number = Math.random): number {
+  return Math.round(500 * attempt * (0.8 + random() * 0.4));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ export type { UF, AuthorizerCode } from '@monitor-sefaz/catalog';
 // Domínio
 export * from './domain/types.js';
 export * from './domain/errors.js';
+export { backoffMs, defaultSleeper, type Sleeper } from './domain/retry.js';
 
 // Envelopes (Strategy por documento)
 export type { EnvelopeBuilder, EnvelopeParams } from './envelopes/EnvelopeBuilder.js';
@@ -52,6 +53,7 @@ export {
   AvailabilityParser,
   DOCUMENT_COLUMNS,
   type AvailabilityRow,
+  type AvailabilityParseResult,
   type ColumnLayout,
 } from './availability/AvailabilityParser.js';
 export {
@@ -89,4 +91,9 @@ export { createHttpSvrsFetcher } from './svrs/httpFetcher.js';
 export { SvrsCollector } from './svrs/SvrsCollector.js';
 
 // Consenso multi-fonte (precedência oficial)
-export { ConsensusCollector, type ConsensusSource } from './consensus/ConsensusCollector.js';
+export {
+  ConsensusCollector,
+  type ConsensusSource,
+  type SourceHealth,
+  type ConsensusResult,
+} from './consensus/ConsensusCollector.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -97,3 +97,15 @@ export {
   type SourceHealth,
   type ConsensusResult,
 } from './consensus/ConsensusCollector.js';
+
+// Notas Técnicas (lista de conteúdo do portal)
+export {
+  parseTechnicalNotes,
+  type TechnicalNote,
+} from './technical-notes/TechnicalNotesParser.js';
+export {
+  TechnicalNotesProvider,
+  TECHNICAL_NOTES_URL,
+  type TechnicalNotesFetcher,
+} from './technical-notes/TechnicalNotesProvider.js';
+export { createHttpTechnicalNotesFetcher } from './technical-notes/httpFetcher.js';

--- a/packages/core/src/integranotas/IntegraNotasProvider.ts
+++ b/packages/core/src/integranotas/IntegraNotasProvider.ts
@@ -1,5 +1,6 @@
 import { DocumentType, type UF } from '@monitor-sefaz/catalog';
 import { ServiceState } from '../domain/types.js';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 
 /** Status por UF de um documento, como exposto pelo IntegraNotas. */
 export interface IntegraNotasRow {
@@ -88,18 +89,47 @@ export class IntegraNotasProvider {
   constructor(
     private readonly fetcher: IntegraNotasFetcher,
     /** Relógio em ms; injetável para os testes serem determinísticos. */
-    private readonly now: () => number = () => Date.now()
+    private readonly now: () => number = () => Date.now(),
+    /** Sleeper do backoff entre tentativas; injetável para os testes não dormirem. */
+    private readonly sleep: Sleeper = defaultSleeper,
+    /** Fonte de aleatoriedade do jitter; injetável para o backoff ser determinístico. */
+    private readonly random: () => number = Math.random
   ) {}
 
   public supportedDocuments(): DocumentType[] {
     return Object.keys(INTEGRANOTAS_DOCUMENTS) as DocumentType[];
   }
 
-  public async fetch(document: DocumentType): Promise<IntegraNotasFetchResult> {
+  /**
+   * Busca e parseia a disponibilidade de um documento. Tenta algumas vezes com
+   * backoff: o IntegraNotas é a única fonte que cobre UF-a-UF de forma completa
+   * (preenche as lacunas das oficiais no consenso), então uma falha transitória
+   * de rede aqui deixaria várias UFs sem dado. Como nas demais fontes ao vivo, se
+   * todas as tentativas falharem LANÇA — o `IntegraNotasCollector` então pula o
+   * documento (parse estrito, para não mascarar as fontes oficiais).
+   */
+  public async fetch(document: DocumentType, attempts = 3): Promise<IntegraNotasFetchResult> {
     const slug = INTEGRANOTAS_DOCUMENTS[document];
     if (!slug) {
       return { rows: [], fetchLatencyMs: 0 };
     }
+
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        return await this.fetchOnce(slug);
+      } catch (err) {
+        lastError = err;
+      }
+      if (attempt < attempts) {
+        await this.sleep(backoffMs(attempt, this.random));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+
+  /** Uma única tentativa: fetch cronometrado + parse estrito dos arrays paralelos. */
+  private async fetchOnce(slug: string): Promise<IntegraNotasFetchResult> {
     // Cronometra a requisição: esta é a latência de REDE real do documento — a
     // métrica que o front exibe. O tMed do IntegraNotas é tempo médio da SEFAZ
     // em segundos inteiros (grosseiro: 0/1/6s), inútil como latência.
@@ -112,7 +142,7 @@ export class IntegraNotasProvider {
     // backgroundColor[i], normal[i], svc[i]). Se qualquer um desalinhar, lemos o
     // estado/flags de OUTRA UF ou caímos em Error silencioso. Por isso exigimos
     // que todos os presentes tenham o mesmo comprimento de labels; senão lança e
-    // o HybridCollector pula o documento (e cai no fallback se necessário).
+    // o IntegraNotasCollector pula o documento (o consenso segue com as demais fontes).
     const n = d?.labels?.length;
     const lenMismatch = (a?: unknown[]): boolean => Array.isArray(a) && a.length !== n;
     if (

--- a/packages/core/src/svrs/SvrsProvider.ts
+++ b/packages/core/src/svrs/SvrsProvider.ts
@@ -1,5 +1,5 @@
 import { DocumentType } from '@monitor-sefaz/catalog';
-import { backoffMs, type Sleeper } from '../availability/AvailabilityProvider.js';
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
 import { SvrsParser, type SvrsAuthorizerStatus } from './SvrsParser.js';
 
 /**
@@ -17,8 +17,6 @@ export const SVRS_URLS: Partial<Record<DocumentType, string>> = {
   [DocumentType.MDFe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
   [DocumentType.DCe]: 'https://dfe-portal.svrs.rs.gov.br/Mdfe/Disponibilidade',
 };
-
-const defaultSleeper: Sleeper = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 /**
  * Transporte HTTP injetável (axios no Node via `createHttpSvrsFetcher`, fetch

--- a/packages/core/src/technical-notes/TechnicalNotesParser.ts
+++ b/packages/core/src/technical-notes/TechnicalNotesParser.ts
@@ -1,0 +1,53 @@
+import * as cheerio from 'cheerio';
+
+/** Uma Nota Técnica publicada no portal (lista de conteúdo). */
+export interface TechnicalNote {
+  /** Título exibido (texto do span.tituloConteudo). */
+  readonly title: string;
+  /** Link relativo/absoluto para o conteúdo, quando presente. */
+  readonly link: string | null;
+}
+
+const PORTAL_BASE = 'https://www.nfe.fazenda.gov.br/portal/';
+
+/** Normaliza um href relativo do portal para URL absoluta; mantém http(s) como está. */
+function absolutize(href: string | undefined): string | null {
+  if (!href) return null;
+  const clean = href.trim().replace(/\s/g, '');
+  if (!clean) return null;
+  if (/^https?:\/\//i.test(clean)) return clean;
+  return `${PORTAL_BASE}${clean.replace(/^\/+/, '')}`;
+}
+
+/**
+ * Parser da lista de Notas Técnicas do portal da NF-e
+ * (`listaConteudo.aspx?tipoConteudo=...`). Cada item é um `<span class="tituloConteudo">`
+ * dentro de um `<a>`; o link é o `href` desse âncora.
+ *
+ * Correções sobre monitores ingênuos: extrai TODAS as notas da página (não só a
+ * primeira) e PERSISTE o link. Função pura, testável por fixture.
+ */
+export function parseTechnicalNotes(html: string): TechnicalNote[] {
+  const $ = cheerio.load(html);
+  const notes: TechnicalNote[] = [];
+  const seen = new Set<string>();
+
+  $('span.tituloConteudo').each((_, span) => {
+    const $span = $(span);
+    const title = $span.text().trim().replace(/\s+/g, ' ');
+    if (!title) return;
+
+    // O link é o href do <a> ancestral mais próximo (quando existe).
+    const href = $span.closest('a').attr('href') ?? $span.parent('a').attr('href');
+    const link = absolutize(href);
+
+    // Dedup por título+link dentro da mesma página (evita repetição de markup).
+    const key = `${title}|${link ?? ''}`;
+    if (seen.has(key)) return;
+    seen.add(key);
+
+    notes.push({ title, link });
+  });
+
+  return notes;
+}

--- a/packages/core/src/technical-notes/TechnicalNotesProvider.ts
+++ b/packages/core/src/technical-notes/TechnicalNotesProvider.ts
@@ -1,0 +1,45 @@
+import { backoffMs, defaultSleeper, type Sleeper } from '../domain/retry.js';
+import { parseTechnicalNotes, type TechnicalNote } from './TechnicalNotesParser.js';
+
+/** URL da lista de Notas Técnicas da NF-e (produção). */
+export const TECHNICAL_NOTES_URL =
+  'https://www.nfe.fazenda.gov.br/portal/listaConteudo.aspx?tipoConteudo=04BIflQt1aY=';
+
+/** Transporte HTTP injetável (axios no Node, fetch no Worker); devolve HTML. */
+export interface TechnicalNotesFetcher {
+  (url: string): Promise<string>;
+}
+
+/**
+ * Cliente da lista de Notas Técnicas do portal da NF-e. Mesma estratégia das
+ * demais fontes ao vivo: transporte injetado + retry com backoff. Se todas as
+ * tentativas falharem ou não trouxerem notas, LANÇA (o collector então pula sem
+ * publicar uma lista vazia por engano).
+ */
+export class TechnicalNotesProvider {
+  constructor(
+    private readonly fetcher: TechnicalNotesFetcher,
+    private readonly sleep: Sleeper = defaultSleeper,
+    private readonly random: () => number = Math.random
+  ) {}
+
+  public async fetch(attempts = 3): Promise<TechnicalNote[]> {
+    let lastError: unknown;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      try {
+        const html = await this.fetcher(TECHNICAL_NOTES_URL);
+        const notes = parseTechnicalNotes(html);
+        if (notes.length > 0) {
+          return notes;
+        }
+        lastError = new Error('lista de notas técnicas vazia');
+      } catch (err) {
+        lastError = err;
+      }
+      if (attempt < attempts) {
+        await this.sleep(backoffMs(attempt, this.random));
+      }
+    }
+    throw lastError instanceof Error ? lastError : new Error(String(lastError));
+  }
+}

--- a/packages/core/src/technical-notes/httpFetcher.ts
+++ b/packages/core/src/technical-notes/httpFetcher.ts
@@ -1,0 +1,34 @@
+import axios, { type AxiosInstance } from 'axios';
+import { wrapper } from 'axios-cookiejar-support';
+import { CookieJar } from 'tough-cookie';
+import type { TechnicalNotesFetcher } from './TechnicalNotesProvider.js';
+
+const BROWSER_UA =
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36';
+
+/**
+ * Fetcher das Notas Técnicas para Node (axios + cookie jar). Mesma estratégia do
+ * fetcher do SVRS/disponibilidade: o portal usa AspxAutoDetectCookieSupport e a
+ * página é latin-1.
+ */
+export function createHttpTechnicalNotesFetcher(timeoutMs = 20_000): TechnicalNotesFetcher {
+  const jar = new CookieJar();
+  const http: AxiosInstance = wrapper(
+    axios.create({
+      jar,
+      timeout: timeoutMs,
+      maxRedirects: 15,
+      responseType: 'arraybuffer',
+      headers: {
+        'User-Agent': BROWSER_UA,
+        Accept: 'text/html,application/xhtml+xml',
+        'Accept-Language': 'pt-BR,pt;q=0.9',
+      },
+      validateStatus: () => true,
+    })
+  );
+  return async (url) => {
+    const res = await http.get<ArrayBuffer>(url);
+    return Buffer.from(res.data).toString('latin1');
+  };
+}

--- a/packages/core/test/availability/AvailabilityParser.test.ts
+++ b/packages/core/test/availability/AvailabilityParser.test.ts
@@ -79,4 +79,53 @@ describe('AvailabilityParser', () => {
   it('ignora HTML sem tabela de status', () => {
     expect(parser.parse('<html><body><p>sem tabela</p></body></html>')).toEqual([]);
   });
+
+  describe('resolução por cabeçalho (defensivo a mudança de layout)', () => {
+    it('nas páginas reais, resolve as colunas pelo cabeçalho (headerMatched)', () => {
+      const nfe = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(
+        loadAvailability('nfe-disponibilidade.html')
+      );
+      const cte = new AvailabilityParser(DocumentType.CTe).parseWithDiagnostics(
+        loadAvailability('cte-disponibilidade.html')
+      );
+      expect(nfe.headerMatched).toBe(true);
+      expect(cte.headerMatched).toBe(true);
+      expect(nfe.rows.length).toBeGreaterThanOrEqual(12);
+      expect(cte.rows.length).toBeGreaterThanOrEqual(6);
+    });
+
+    it('acha a coluna certa pelo cabeçalho mesmo com layout deslocado', () => {
+      // Cabeçalho diz que "Status Serviço" é a coluna 3 (não a 5 do layout NF-e).
+      // Uma coluna nova foi inserida; o índice fixo leria a coluna errada.
+      const html = `<table>
+        <tr><th>Autorizador</th><th>Coluna Nova</th><th>Autorização</th>
+            <th>Status Serviço</th><th>Retorno</th><th>Consulta</th><th>Tempo Médio</th></tr>
+        <tr>
+          <td>SP</td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_verde.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td><img src="bola_vermelho.png"></td>
+          <td>2</td>
+        </tr></table>`;
+      // Parser com layout NF-e (statusIndex fixo=5), mas o cabeçalho manda.
+      const res = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(html);
+      expect(res.headerMatched).toBe(true);
+      expect(res.rows[0]?.state).toBe(ServiceState.Operational); // coluna 3 (verde), não a 5
+      expect(res.rows[0]?.tMedSeconds).toBe(2); // "Tempo Médio" achado na coluna 6
+    });
+
+    it('cai no índice fixo e sinaliza headerMatched=false quando não há cabeçalho', () => {
+      // HTML sem <th>: não dá para validar o layout → fallback + sinal de drift.
+      const html = `<table><tr>
+        <td>SP</td><td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+        <td><img src="bola_verde.png"></td><td><img src="bola_verde.png"></td>
+        <td><img src="bola_verde.png"></td><td>1</td>
+      </tr></table>`;
+      const res = new AvailabilityParser(DocumentType.NFe).parseWithDiagnostics(html);
+      expect(res.headerMatched).toBe(false); // sem cabeçalho → possível drift
+      expect(res.rows[0]?.state).toBe(ServiceState.Operational); // fallback índice 5 ainda funciona
+    });
+  });
 });

--- a/packages/core/test/availability/backoff.test.ts
+++ b/packages/core/test/availability/backoff.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { backoffMs } from '../../src/availability/AvailabilityProvider.js';
+import { backoffMs } from '../../src/domain/retry.js';
 
 describe('backoffMs', () => {
   it('é linear na tentativa (base 500ms × attempt) sem jitter', () => {

--- a/packages/core/test/consensus/ConsensusCollector.test.ts
+++ b/packages/core/test/consensus/ConsensusCollector.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { DocumentType, type UF } from '@monitor-sefaz/catalog';
+import { Catalog, DocumentType, type UF } from '@monitor-sefaz/catalog';
 import { ConsensusCollector } from '../../src/consensus/ConsensusCollector.js';
 import { ServiceState } from '../../src/domain/types.js';
 import type { CollectedStatus } from '../../src/availability/AvailabilityCollector.js';
@@ -98,5 +98,74 @@ describe('ConsensusCollector', () => {
     const out = await consensus.collect();
     expect(out).toHaveLength(1);
     expect(out[0]!.source).toBe('integranotas');
+  });
+
+  describe('collectWithDiagnostics (sinal de drift)', () => {
+    // expected = 135 (5 docs × 27 UFs em produção). Com ratio 0.015, floor = 2:
+    // uma fonte com 1 serviço fica degraded; com 2+ fica saudável. Assim testamos
+    // os dois lados sem montar 100+ serviços à mão.
+    const RATIO = 0.015;
+
+    it('reporta cobertura por fonte e marca degraded abaixo do piso', async () => {
+      // svrs traz só 1 serviço (degraded); integranotas traz 3 (saudável).
+      const svrs = fake([status('SP', ServiceState.Operational, 'svrs')]);
+      const third = fake([
+        status('SP', ServiceState.Operational, 'integranotas'),
+        status('AM', ServiceState.Operational, 'integranotas'),
+        status('BA', ServiceState.Operational, 'integranotas'),
+      ]);
+      const consensus = new ConsensusCollector(
+        [
+          { name: 'svrs', official: true, collector: svrs },
+          { name: 'integranotas', official: false, collector: third },
+        ],
+        new Catalog(),
+        RATIO
+      );
+
+      const { services, sources } = await consensus.collectWithDiagnostics();
+      // Os serviços continuam saindo como sempre (SP decidido pela oficial).
+      expect(services.find((s) => s.uf === 'SP')!.source).toBe('svrs');
+
+      const svrsHealth = sources.find((s) => s.source === 'svrs')!;
+      expect(svrsHealth.collected).toBe(1);
+      expect(svrsHealth.expected).toBe(135);
+      expect(svrsHealth.degraded).toBe(true); // 1 < floor(135*0.015)=2 → drift
+
+      const thirdHealth = sources.find((s) => s.source === 'integranotas')!;
+      expect(thirdHealth.collected).toBe(3);
+      expect(thirdHealth.degraded).toBe(false); // 3 ≥ 2 → saudável
+    });
+
+    it('uma fonte que lança fica com collected=0 e degraded=true', async () => {
+      const broken = fake([], true);
+      const ok = fake([
+        status('SP', ServiceState.Operational, 'integranotas'),
+        status('AM', ServiceState.Operational, 'integranotas'),
+      ]);
+      const consensus = new ConsensusCollector(
+        [
+          { name: 'svrs', official: true, collector: broken },
+          { name: 'integranotas', official: false, collector: ok },
+        ],
+        new Catalog(),
+        RATIO
+      );
+
+      const { sources } = await consensus.collectWithDiagnostics();
+      const svrsHealth = sources.find((s) => s.source === 'svrs')!;
+      expect(svrsHealth.collected).toBe(0);
+      expect(svrsHealth.degraded).toBe(true);
+      expect(svrsHealth.official).toBe(true);
+    });
+
+    it('collect() continua devolvendo só os serviços (retrocompat)', async () => {
+      const consensus = new ConsensusCollector([
+        { name: 'svrs', official: true, collector: fake([status('SP', ServiceState.Operational, 'svrs')]) },
+      ]);
+      const out = await consensus.collect();
+      expect(Array.isArray(out)).toBe(true);
+      expect(out[0]!.uf).toBe('SP');
+    });
   });
 });

--- a/packages/core/test/fixtures/technical-notes/lista.html
+++ b/packages/core/test/fixtures/technical-notes/lista.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="pt-br">
+<head><title>Portal da NF-e - Notas Técnicas</title></head>
+<body>
+  <div id="conteudoDinamico">
+    <p>
+      <a href="exibirArquivo.aspx?conteudo=abc123=">
+        <span class="tituloConteudo">Nota Técnica 2024.001 - Novo layout NFe</span>
+      </a>
+      <br />
+      Publicada em 10/01/2024.
+    </p>
+    <p>
+      <a href="exibirArquivo.aspx?conteudo=def456=">
+        <span class="tituloConteudo">Nota Técnica 2023.004 - Ajustes de validação</span>
+      </a>
+      <br />
+      Publicada em 20/12/2023.
+    </p>
+    <p>
+      <a href="https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=ghi789=">
+        <span class="tituloConteudo">Nota Técnica 2023.003 - Eventos</span>
+      </a>
+    </p>
+  </div>
+</body>
+</html>

--- a/packages/core/test/integranotas/IntegraNotasProvider.test.ts
+++ b/packages/core/test/integranotas/IntegraNotasProvider.test.ts
@@ -51,18 +51,21 @@ describe('IntegraNotasProvider', () => {
     expect(fetchLatencyMs).toBe(137);
   });
 
+  // Sleeper fake para os testes de erro não dormirem os retries de verdade.
+  const skipSleep = async (): Promise<void> => {};
+
   it('lança quando o payload não tem dados.labels', async () => {
-    const provider = new IntegraNotasProvider(async () => '{"dados":{}}');
+    const provider = new IntegraNotasProvider(async () => '{"dados":{}}', undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow();
   });
 
   it('lança quando há labels/backgroundColor mas falta o array data', async () => {
     // Sem essa guarda, todas as UFs virariam Error silenciosamente (tMed=-1) e o
-    // fallback do híbrido nunca dispararia.
+    // consenso não saberia que a fonte falhou.
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto/);
   });
 
@@ -70,7 +73,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''], data: [1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/incompleto|desalinhad/);
   });
 
@@ -78,7 +81,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: [''], data: [1, 1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/desalinhad|incompleto/);
   });
 
@@ -86,7 +89,7 @@ describe('IntegraNotasProvider', () => {
     const payload = JSON.stringify({
       dados: { labels: ['SP', 'RJ'], backgroundColor: ['', ''], data: [1, 1], normal: [1] },
     });
-    const provider = new IntegraNotasProvider(async () => payload);
+    const provider = new IntegraNotasProvider(async () => payload, undefined, skipSleep);
     await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/desalinhad|incompleto/);
   });
 
@@ -96,5 +99,47 @@ describe('IntegraNotasProvider', () => {
     expect(docs).toContain(DocumentType.MDFe);
     expect(docs).toContain(DocumentType.DCe);
     expect(docs).toHaveLength(5);
+  });
+
+  // Sleeper fake: não dorme de verdade, só registra os atrasos pedidos.
+  const noSleep = (delays: number[]) => async (ms: number) => {
+    delays.push(ms);
+  };
+  const fixedRandom = (): number => 0.5; // jitter neutro → backoff = 500 × attempt
+
+  it('faz retry com backoff e tem sucesso após uma falha transitória', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const provider = new IntegraNotasProvider(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('ECONNRESET transitório');
+        return nfeFixture;
+      },
+      () => 0,
+      noSleep(delays),
+      fixedRandom
+    );
+    const { rows } = await provider.fetch(DocumentType.NFe);
+    expect(calls).toBe(2); // falhou 1×, sucesso na 2ª
+    expect(rows).toHaveLength(27);
+    expect(delays).toEqual([500]); // um backoff entre a 1ª e a 2ª tentativa
+  });
+
+  it('lança após esgotar as tentativas (parse estrito preservado)', async () => {
+    const delays: number[] = [];
+    let calls = 0;
+    const provider = new IntegraNotasProvider(
+      async () => {
+        calls += 1;
+        throw new Error('sempre falha');
+      },
+      () => 0,
+      noSleep(delays),
+      fixedRandom
+    );
+    await expect(provider.fetch(DocumentType.NFe)).rejects.toThrow(/sempre falha/);
+    expect(calls).toBe(3); // attempts=3 por padrão
+    expect(delays).toEqual([500, 1000]); // backoff só ENTRE tentativas, não após a última
   });
 });

--- a/packages/core/test/technical-notes/TechnicalNotesParser.test.ts
+++ b/packages/core/test/technical-notes/TechnicalNotesParser.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { parseTechnicalNotes } from '../../src/technical-notes/TechnicalNotesParser.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = readFileSync(
+  join(here, '..', 'fixtures', 'technical-notes', 'lista.html'),
+  'latin1'
+);
+
+describe('parseTechnicalNotes', () => {
+  it('extrai TODAS as notas da lista (não só a primeira)', () => {
+    const notes = parseTechnicalNotes(fixture);
+    expect(notes).toHaveLength(3);
+    expect(notes.map((n) => n.title)).toEqual([
+      'Nota Técnica 2024.001 - Novo layout NFe',
+      'Nota Técnica 2023.004 - Ajustes de validação',
+      'Nota Técnica 2023.003 - Eventos',
+    ]);
+  });
+
+  it('persiste o link, absolutizando href relativo do portal', () => {
+    const notes = parseTechnicalNotes(fixture);
+    expect(notes[0]!.link).toBe(
+      'https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=abc123='
+    );
+    // href já absoluto é mantido
+    expect(notes[2]!.link).toBe(
+      'https://www.nfe.fazenda.gov.br/portal/exibirArquivo.aspx?conteudo=ghi789='
+    );
+  });
+
+  it('página sem notas devolve lista vazia', () => {
+    expect(parseTechnicalNotes('<html><body><p>nada aqui</p></body></html>')).toEqual([]);
+  });
+
+  it('deduplica títulos+link repetidos na mesma página', () => {
+    const dup = `<div>
+      <a href="x.aspx"><span class="tituloConteudo">NT Repetida</span></a>
+      <a href="x.aspx"><span class="tituloConteudo">NT Repetida</span></a>
+    </div>`;
+    expect(parseTechnicalNotes(dup)).toHaveLength(1);
+  });
+});

--- a/packages/core/test/technical-notes/TechnicalNotesProvider.test.ts
+++ b/packages/core/test/technical-notes/TechnicalNotesProvider.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { TechnicalNotesProvider } from '../../src/technical-notes/TechnicalNotesProvider.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixture = readFileSync(
+  join(here, '..', 'fixtures', 'technical-notes', 'lista.html'),
+  'latin1'
+);
+const noSleep = async (): Promise<void> => {};
+
+describe('TechnicalNotesProvider', () => {
+  it('parseia a fixture real (3 notas)', async () => {
+    const provider = new TechnicalNotesProvider(async () => fixture, noSleep);
+    const notes = await provider.fetch();
+    expect(notes).toHaveLength(3);
+  });
+
+  it('faz retry e tem sucesso após falha transitória', async () => {
+    let calls = 0;
+    const provider = new TechnicalNotesProvider(
+      async () => {
+        calls += 1;
+        if (calls === 1) throw new Error('rede caiu');
+        return fixture;
+      },
+      noSleep,
+      () => 0.5
+    );
+    const notes = await provider.fetch();
+    expect(calls).toBe(2);
+    expect(notes).toHaveLength(3);
+  });
+
+  it('lança após esgotar as tentativas', async () => {
+    const provider = new TechnicalNotesProvider(
+      async () => {
+        throw new Error('sempre falha');
+      },
+      noSleep,
+      () => 0.5
+    );
+    await expect(provider.fetch()).rejects.toThrow(/sempre falha/);
+  });
+});

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -16,5 +16,8 @@
   },
   "dependencies": {
     "@monitor-sefaz/contracts": "workspace:*"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2"
   }
 }

--- a/packages/notifier/package.json
+++ b/packages/notifier/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "@monitor-sefaz/notifier",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "scripts": {
+    "build": "tsc -b tsconfig.json",
+    "typecheck": "tsc -b tsconfig.json",
+    "lint": "eslint src",
+    "test": "vitest run --passWithNoTests"
+  },
+  "dependencies": {
+    "@monitor-sefaz/contracts": "workspace:*"
+  }
+}

--- a/packages/notifier/src/Notifier.ts
+++ b/packages/notifier/src/Notifier.ts
@@ -1,0 +1,47 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import type { NotifierConfig } from './config.js';
+
+/** Resultado do fan-out: quantas entregas deram certo/erraram. */
+export interface NotifyResult {
+  readonly sent: number;
+  readonly failed: number;
+}
+
+/**
+ * Orquestra a entrega dos eventos aos canais configurados. Faz o produto
+ * eventos × canais e envia tudo em paralelo com `allSettled`: uma falha (canal
+ * fora do ar, URL inválida) é contabilizada mas NÃO interrompe as demais entregas.
+ *
+ * Sem canais configurados, `notify` é no-op — o pipeline de coleta segue idêntico
+ * quando ninguém habilitou notificação.
+ */
+export class Notifier {
+  constructor(private readonly config: NotifierConfig) {}
+
+  /** Há ao menos um canal ativo? Útil para pular trabalho quando desligado. */
+  public get enabled(): boolean {
+    return this.config.channels.length > 0;
+  }
+
+  public async notify(events: readonly NotificationEventDTO[]): Promise<NotifyResult> {
+    const { channels, eventFilter } = this.config;
+    if (channels.length === 0 || events.length === 0) {
+      return { sent: 0, failed: 0 };
+    }
+
+    const selected = eventFilter
+      ? events.filter((e) => eventFilter.has(e.type))
+      : events;
+
+    const deliveries: Array<Promise<void>> = [];
+    for (const event of selected) {
+      for (const channel of channels) {
+        deliveries.push(channel.send(event));
+      }
+    }
+
+    const results = await Promise.allSettled(deliveries);
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    return { sent: results.length - failed, failed };
+  }
+}

--- a/packages/notifier/src/channels/Channel.ts
+++ b/packages/notifier/src/channels/Channel.ts
@@ -1,0 +1,86 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+
+/** Transporte HTTP injetável (fetch nativo em prod; fake nos testes). */
+export type FetchLike = (
+  url: string,
+  init: { method: string; headers: Record<string, string>; body: string }
+) => Promise<{ ok: boolean; status: number }>;
+
+/** Um destino de notificação. `send` resolve em sucesso e REJEITA em falha. */
+export interface Channel {
+  readonly name: string;
+  send(event: NotificationEventDTO): Promise<void>;
+}
+
+/** Opções comuns de entrega. */
+export interface DeliveryOptions {
+  readonly fetchImpl?: FetchLike;
+  /** Timeout por tentativa (ms). */
+  readonly timeoutMs?: number;
+  /** Sleeper injetável do retry (não dorme nos testes). */
+  readonly sleep?: (ms: number) => Promise<void>;
+}
+
+const defaultSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+/** `fetch` default embrulhado no formato mínimo do `FetchLike`. */
+const defaultFetch: FetchLike = async (url, init) => {
+  const res = await fetch(url, init);
+  return { ok: res.ok, status: res.status };
+};
+
+/**
+ * POST JSON com timeout e UMA retentativa. Robustez que falta a scrapers ingênuos:
+ * uma falha transitória de rede não perde a notificação, mas também não trava (o
+ * timeout aborta) nem repete infinitamente. Lança se ambas as tentativas falharem
+ * — quem orquestra (Notifier) isola cada canal com allSettled.
+ */
+export async function postJson(
+  url: string,
+  payload: unknown,
+  opts: DeliveryOptions = {}
+): Promise<void> {
+  const doFetch = opts.fetchImpl ?? defaultFetch;
+  const sleep = opts.sleep ?? defaultSleep;
+  const timeoutMs = opts.timeoutMs ?? 10_000;
+  const body = JSON.stringify(payload);
+  const headers = { 'Content-Type': 'application/json' };
+
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= 2; attempt += 1) {
+    try {
+      const res = await withTimeout(
+        doFetch(url, { method: 'POST', headers, body }),
+        timeoutMs
+      );
+      if (res.ok) {
+        return;
+      }
+      lastError = new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    if (attempt === 1) {
+      await sleep(500); // backoff curto antes da única retentativa
+    }
+  }
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/** Rejeita se a promessa não resolver dentro de `ms`. */
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`timeout após ${ms}ms`)), ms);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e instanceof Error ? e : new Error(String(e)));
+      }
+    );
+  });
+}

--- a/packages/notifier/src/channels/DiscordChannel.ts
+++ b/packages/notifier/src/channels/DiscordChannel.ts
@@ -1,0 +1,17 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { toDiscordPayload } from '../format/discord.js';
+import { postJson, type Channel, type DeliveryOptions } from './Channel.js';
+
+/** Entrega eventos a um webhook do Discord (embed por evento). */
+export class DiscordChannel implements Channel {
+  public readonly name = 'discord';
+
+  constructor(
+    private readonly webhookUrl: string,
+    private readonly opts: DeliveryOptions = {}
+  ) {}
+
+  public async send(event: NotificationEventDTO): Promise<void> {
+    await postJson(this.webhookUrl, toDiscordPayload(event), this.opts);
+  }
+}

--- a/packages/notifier/src/channels/SlackChannel.ts
+++ b/packages/notifier/src/channels/SlackChannel.ts
@@ -1,0 +1,17 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { toSlackPayload } from '../format/slack.js';
+import { postJson, type Channel, type DeliveryOptions } from './Channel.js';
+
+/** Entrega eventos a um Incoming Webhook do Slack (attachment por evento). */
+export class SlackChannel implements Channel {
+  public readonly name = 'slack';
+
+  constructor(
+    private readonly webhookUrl: string,
+    private readonly opts: DeliveryOptions = {}
+  ) {}
+
+  public async send(event: NotificationEventDTO): Promise<void> {
+    await postJson(this.webhookUrl, toSlackPayload(event), this.opts);
+  }
+}

--- a/packages/notifier/src/channels/TelegramChannel.ts
+++ b/packages/notifier/src/channels/TelegramChannel.ts
@@ -1,0 +1,24 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { toTelegramPayload } from '../format/telegram.js';
+import { postJson, type Channel, type DeliveryOptions } from './Channel.js';
+
+/**
+ * Entrega eventos via Bot API do Telegram (sendMessage). Precisa do token do bot
+ * e do chat de destino; a URL do endpoint é derivada do token.
+ */
+export class TelegramChannel implements Channel {
+  public readonly name = 'telegram';
+  private readonly url: string;
+
+  constructor(
+    botToken: string,
+    private readonly chatId: string,
+    private readonly opts: DeliveryOptions = {}
+  ) {
+    this.url = `https://api.telegram.org/bot${botToken}/sendMessage`;
+  }
+
+  public async send(event: NotificationEventDTO): Promise<void> {
+    await postJson(this.url, toTelegramPayload(event, this.chatId), this.opts);
+  }
+}

--- a/packages/notifier/src/channels/WebhookChannel.ts
+++ b/packages/notifier/src/channels/WebhookChannel.ts
@@ -1,0 +1,20 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { postJson, type Channel, type DeliveryOptions } from './Channel.js';
+
+/**
+ * Webhook genérico: envia o próprio NotificationEvent como JSON cru, deixando a
+ * formatação para o consumidor. Útil para integrações que não são Discord/Slack/
+ * Telegram (um endpoint próprio, um n8n, etc.).
+ */
+export class WebhookChannel implements Channel {
+  public readonly name = 'webhook';
+
+  constructor(
+    private readonly url: string,
+    private readonly opts: DeliveryOptions = {}
+  ) {}
+
+  public async send(event: NotificationEventDTO): Promise<void> {
+    await postJson(this.url, event, this.opts);
+  }
+}

--- a/packages/notifier/src/config.ts
+++ b/packages/notifier/src/config.ts
@@ -1,0 +1,60 @@
+import type { NotificationEventType } from '@monitor-sefaz/contracts';
+import type { Channel, DeliveryOptions } from './channels/Channel.js';
+import { DiscordChannel } from './channels/DiscordChannel.js';
+import { SlackChannel } from './channels/SlackChannel.js';
+import { TelegramChannel } from './channels/TelegramChannel.js';
+import { WebhookChannel } from './channels/WebhookChannel.js';
+
+/** Fonte de variáveis de ambiente (process.env ou um objeto nos testes). */
+export type Env = Record<string, string | undefined>;
+
+/** Configuração resolvida do notifier. */
+export interface NotifierConfig {
+  /** Canais ativos (só os que têm as vars necessárias). */
+  readonly channels: Channel[];
+  /** Filtro de tipos de evento; `null` = todos. */
+  readonly eventFilter: Set<NotificationEventType> | null;
+}
+
+/**
+ * Monta a configuração do notifier a partir do ambiente. Cada canal só é ativado
+ * quando SUAS variáveis existem — sem nenhuma var, `channels` fica vazio e o
+ * Notifier vira no-op (zero efeito no pipeline atual). NOTIFY_EVENTS (csv) filtra
+ * os tipos; ausente = todos.
+ *
+ * Vars:
+ * - NOTIFY_DISCORD_WEBHOOK_URL
+ * - NOTIFY_SLACK_WEBHOOK_URL
+ * - NOTIFY_TELEGRAM_BOT_TOKEN + NOTIFY_TELEGRAM_CHAT_ID (ambos obrigatórios)
+ * - NOTIFY_WEBHOOK_URL
+ * - NOTIFY_EVENTS (ex.: "SERVICE_DOWN,SERVICE_RECOVERED")
+ */
+export function parseNotifierConfig(env: Env, opts: DeliveryOptions = {}): NotifierConfig {
+  const channels: Channel[] = [];
+
+  const discord = env.NOTIFY_DISCORD_WEBHOOK_URL;
+  if (discord) channels.push(new DiscordChannel(discord, opts));
+
+  const slack = env.NOTIFY_SLACK_WEBHOOK_URL;
+  if (slack) channels.push(new SlackChannel(slack, opts));
+
+  const botToken = env.NOTIFY_TELEGRAM_BOT_TOKEN;
+  const chatId = env.NOTIFY_TELEGRAM_CHAT_ID;
+  if (botToken && chatId) channels.push(new TelegramChannel(botToken, chatId, opts));
+
+  const webhook = env.NOTIFY_WEBHOOK_URL;
+  if (webhook) channels.push(new WebhookChannel(webhook, opts));
+
+  const rawFilter = env.NOTIFY_EVENTS?.trim();
+  const eventFilter =
+    rawFilter && rawFilter.length > 0
+      ? new Set(
+          rawFilter
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean) as NotificationEventType[]
+        )
+      : null;
+
+  return { channels, eventFilter };
+}

--- a/packages/notifier/src/diff.ts
+++ b/packages/notifier/src/diff.ts
@@ -1,0 +1,78 @@
+import {
+  isUp,
+  type NotificationEventDTO,
+  type ServiceStatusDTO,
+} from '@monitor-sefaz/contracts';
+
+/** Um serviço com o mínimo que a detecção de transição precisa. */
+type ServiceLike = Pick<
+  ServiceStatusDTO,
+  'id' | 'uf' | 'document' | 'state' | 'cStat' | 'source'
+>;
+
+const CONTINGENCY = 'CONTINGENCY';
+
+/**
+ * Detecta as transições de estado entre dois snapshots e as traduz em eventos de
+ * notificação. Função PURA — é a fonte única de verdade da semântica de eventos,
+ * reusada tanto no Scheduler da API (que guarda `prev` num Map em memória) quanto
+ * no collector (que reconstrói `prev` do history.json). Não faz I/O.
+ *
+ * Regras (espelham a semântica de mudança de estado do Scheduler):
+ * - BASELINE: um serviço presente em `next` mas AUSENTE em `prev` não gera evento
+ *   (não sabemos o estado anterior; a primeira coleta nunca "alarma").
+ * - Disponibilidade (via `isUp`, que trata CONTINGENCY como "no ar"):
+ *     up → !up  ⇒ SERVICE_DOWN
+ *     !up → up  ⇒ SERVICE_RECOVERED
+ * - Contingência (independente de DOWN/RECOVERED, pois isUp(CONTINGENCY)===true):
+ *     ≠CONTINGENCY → CONTINGENCY  ⇒ CONTINGENCY_ENTERED
+ *     CONTINGENCY → ≠CONTINGENCY  ⇒ CONTINGENCY_EXITED
+ *
+ * Um mesmo serviço pode emitir DOIS eventos numa transição (ex.: DOWN→CONTINGENCY
+ * gera SERVICE_RECOVERED **e** CONTINGENCY_ENTERED) — são sinais ortogonais.
+ */
+export function detectTransitions(
+  prev: readonly ServiceLike[],
+  next: readonly ServiceLike[],
+  occurredAt: string
+): NotificationEventDTO[] {
+  const prevById = new Map(prev.map((s) => [s.id, s]));
+  const events: NotificationEventDTO[] = [];
+
+  for (const cur of next) {
+    const before = prevById.get(cur.id);
+    if (!before) {
+      continue; // baseline: sem estado anterior, sem evento
+    }
+    if (before.state === cur.state) {
+      continue; // sem mudança
+    }
+
+    const base = {
+      serviceId: cur.id,
+      uf: cur.uf,
+      document: cur.document,
+      previousState: before.state,
+      currentState: cur.state,
+      cStat: cur.cStat,
+      source: cur.source,
+      occurredAt,
+    };
+
+    // Disponibilidade
+    if (isUp(before.state) && !isUp(cur.state)) {
+      events.push({ ...base, type: 'SERVICE_DOWN' });
+    } else if (!isUp(before.state) && isUp(cur.state)) {
+      events.push({ ...base, type: 'SERVICE_RECOVERED' });
+    }
+
+    // Contingência (ortogonal à disponibilidade)
+    if (before.state !== CONTINGENCY && cur.state === CONTINGENCY) {
+      events.push({ ...base, type: 'CONTINGENCY_ENTERED' });
+    } else if (before.state === CONTINGENCY && cur.state !== CONTINGENCY) {
+      events.push({ ...base, type: 'CONTINGENCY_EXITED' });
+    }
+  }
+
+  return events;
+}

--- a/packages/notifier/src/format/discord.ts
+++ b/packages/notifier/src/format/discord.ts
@@ -1,0 +1,31 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { describeEvent, labelFor } from './labels.js';
+
+/** Payload de webhook do Discord (subset que usamos: um embed). */
+export interface DiscordPayload {
+  embeds: Array<{
+    title: string;
+    description: string;
+    color: number;
+    timestamp: string;
+    footer?: { text: string };
+  }>;
+}
+
+/** Formata um evento como embed do Discord (função pura). */
+export function toDiscordPayload(event: NotificationEventDTO): DiscordPayload {
+  const label = labelFor(event.type);
+  const footer =
+    event.source !== undefined ? { text: `fonte: ${event.source}` } : undefined;
+  return {
+    embeds: [
+      {
+        title: label.title,
+        description: describeEvent(event),
+        color: label.color,
+        timestamp: event.occurredAt,
+        ...(footer ? { footer } : {}),
+      },
+    ],
+  };
+}

--- a/packages/notifier/src/format/labels.ts
+++ b/packages/notifier/src/format/labels.ts
@@ -37,5 +37,14 @@ export function describeEvent(event: NotificationEventDTO): string {
     const title = typeof event.payload?.title === 'string' ? event.payload.title : 'Nota Técnica';
     return title;
   }
+  if (event.type === 'DAILY_DIGEST') {
+    const p = event.payload ?? {};
+    const avail = typeof p.availability === 'number' ? `${p.availability}%` : '—';
+    const op = typeof p.operational === 'number' ? p.operational : '—';
+    const total = typeof p.total === 'number' ? p.total : '—';
+    const degraded = Array.isArray(p.degradedSources) ? p.degradedSources : [];
+    const degradedTxt = degraded.length > 0 ? ` · fontes degradadas: ${degraded.join(', ')}` : '';
+    return `Disponibilidade ${avail} · ${op}/${total} no ar${degradedTxt}`;
+  }
   return labelFor(event.type).title;
 }

--- a/packages/notifier/src/format/labels.ts
+++ b/packages/notifier/src/format/labels.ts
@@ -1,0 +1,41 @@
+import type { NotificationEventDTO, NotificationEventType } from '@monitor-sefaz/contracts';
+
+/** Aparência de um tipo de evento, compartilhada pelos formatters de canal. */
+export interface EventLabel {
+  /** Emoji + texto curto para o título da mensagem. */
+  readonly title: string;
+  /** Cor em RGB inteiro (Discord usa `color`; Slack, hex derivado). */
+  readonly color: number;
+}
+
+const LABELS: Record<NotificationEventType, EventLabel> = {
+  SERVICE_DOWN: { title: '🔴 Serviço fora do ar', color: 0xe4_3f_52 },
+  SERVICE_RECOVERED: { title: '🟢 Serviço normalizado', color: 0x2e_ca_8b },
+  CONTINGENCY_ENTERED: { title: '🟠 Entrou em contingência', color: 0xf1_74_25 },
+  CONTINGENCY_EXITED: { title: '🟢 Saiu de contingência', color: 0x2e_ca_8b },
+  TECHNICAL_NOTE: { title: '📄 Nova Nota Técnica', color: 0x00_99_ff },
+  SOURCE_DEGRADED: { title: '⚠️ Fonte oficial degradada', color: 0xf1_74_25 },
+  DAILY_DIGEST: { title: '📊 Resumo diário', color: 0x00_99_ff },
+};
+
+export function labelFor(type: NotificationEventType): EventLabel {
+  return LABELS[type];
+}
+
+/**
+ * Linha descritiva de um evento, comum a todos os canais. Para eventos de serviço
+ * traz "NFe:SP OPERATIONAL → DOWN"; para os demais, usa o título/payload.
+ */
+export function describeEvent(event: NotificationEventDTO): string {
+  if (event.serviceId && event.previousState && event.currentState) {
+    return `${event.serviceId}: ${event.previousState} → ${event.currentState}`;
+  }
+  if (event.type === 'SOURCE_DEGRADED' && event.source) {
+    return `Fonte ${event.source} abaixo do piso de cobertura`;
+  }
+  if (event.type === 'TECHNICAL_NOTE') {
+    const title = typeof event.payload?.title === 'string' ? event.payload.title : 'Nota Técnica';
+    return title;
+  }
+  return labelFor(event.type).title;
+}

--- a/packages/notifier/src/format/slack.ts
+++ b/packages/notifier/src/format/slack.ts
@@ -1,0 +1,33 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { describeEvent, labelFor } from './labels.js';
+
+/** Payload de Incoming Webhook do Slack (attachment com barra colorida). */
+export interface SlackPayload {
+  attachments: Array<{
+    color: string;
+    title: string;
+    text: string;
+    ts: number;
+  }>;
+}
+
+/** Converte cor RGB inteiro para hex `#rrggbb` (formato que o Slack espera). */
+function toHex(color: number): string {
+  return `#${color.toString(16).padStart(6, '0')}`;
+}
+
+/** Formata um evento como attachment do Slack (função pura). */
+export function toSlackPayload(event: NotificationEventDTO): SlackPayload {
+  const label = labelFor(event.type);
+  return {
+    attachments: [
+      {
+        color: toHex(label.color),
+        title: label.title,
+        text: describeEvent(event),
+        // Slack usa epoch em segundos; occurredAt é ISO. Date.parse é puro.
+        ts: Math.floor(Date.parse(event.occurredAt) / 1000),
+      },
+    ],
+  };
+}

--- a/packages/notifier/src/format/slack.ts
+++ b/packages/notifier/src/format/slack.ts
@@ -25,8 +25,11 @@ export function toSlackPayload(event: NotificationEventDTO): SlackPayload {
         color: toHex(label.color),
         title: label.title,
         text: describeEvent(event),
-        // Slack usa epoch em segundos; occurredAt é ISO. Date.parse é puro.
-        ts: Math.floor(Date.parse(event.occurredAt) / 1000),
+        // Slack usa epoch em segundos; occurredAt é ISO. Guarda contra data
+        // inválida (Date.parse → NaN viraria "ts":null no JSON): cai em 0.
+        ts: Number.isNaN(Date.parse(event.occurredAt))
+          ? 0
+          : Math.floor(Date.parse(event.occurredAt) / 1000),
       },
     ],
   };

--- a/packages/notifier/src/format/telegram.ts
+++ b/packages/notifier/src/format/telegram.ts
@@ -1,0 +1,19 @@
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { describeEvent, labelFor } from './labels.js';
+
+/** Payload do método sendMessage da Bot API do Telegram. */
+export interface TelegramPayload {
+  chat_id: string;
+  text: string;
+  parse_mode: 'Markdown';
+}
+
+/** Formata um evento como mensagem Markdown do Telegram (função pura). */
+export function toTelegramPayload(event: NotificationEventDTO, chatId: string): TelegramPayload {
+  const label = labelFor(event.type);
+  return {
+    chat_id: chatId,
+    text: `*${label.title}*\n${describeEvent(event)}`,
+    parse_mode: 'Markdown',
+  };
+}

--- a/packages/notifier/src/index.ts
+++ b/packages/notifier/src/index.ts
@@ -1,0 +1,1 @@
+export { detectTransitions } from './diff.js';

--- a/packages/notifier/src/index.ts
+++ b/packages/notifier/src/index.ts
@@ -17,3 +17,7 @@ export { DiscordChannel } from './channels/DiscordChannel.js';
 export { SlackChannel } from './channels/SlackChannel.js';
 export { TelegramChannel } from './channels/TelegramChannel.js';
 export { WebhookChannel } from './channels/WebhookChannel.js';
+
+// Config + orquestrador
+export { parseNotifierConfig, type Env, type NotifierConfig } from './config.js';
+export { Notifier, type NotifyResult } from './Notifier.js';

--- a/packages/notifier/src/index.ts
+++ b/packages/notifier/src/index.ts
@@ -1,1 +1,19 @@
 export { detectTransitions } from './diff.js';
+
+// Formatters (funções puras evento → payload)
+export { toDiscordPayload, type DiscordPayload } from './format/discord.js';
+export { toSlackPayload, type SlackPayload } from './format/slack.js';
+export { toTelegramPayload, type TelegramPayload } from './format/telegram.js';
+export { labelFor, describeEvent, type EventLabel } from './format/labels.js';
+
+// Canais (I/O via fetch injetável)
+export {
+  postJson,
+  type Channel,
+  type FetchLike,
+  type DeliveryOptions,
+} from './channels/Channel.js';
+export { DiscordChannel } from './channels/DiscordChannel.js';
+export { SlackChannel } from './channels/SlackChannel.js';
+export { TelegramChannel } from './channels/TelegramChannel.js';
+export { WebhookChannel } from './channels/WebhookChannel.js';

--- a/packages/notifier/test/channels.test.ts
+++ b/packages/notifier/test/channels.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { postJson, type FetchLike } from '../src/channels/Channel.js';
+import { DiscordChannel } from '../src/channels/DiscordChannel.js';
+import { WebhookChannel } from '../src/channels/WebhookChannel.js';
+import { TelegramChannel } from '../src/channels/TelegramChannel.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+const event: NotificationEventDTO = {
+  type: 'SERVICE_DOWN',
+  serviceId: 'NFe:SP',
+  uf: 'SP',
+  previousState: 'OPERATIONAL',
+  currentState: 'DOWN',
+  cStat: 109,
+  occurredAt: AT,
+};
+
+const noSleep = async (): Promise<void> => {};
+
+/** Fetch fake que registra as chamadas e responde conforme uma sequência. */
+function recordingFetch(statuses: Array<number | 'throw'>): {
+  fetch: FetchLike;
+  calls: Array<{ url: string; body: string }>;
+} {
+  const calls: Array<{ url: string; body: string }> = [];
+  let i = 0;
+  const fetch: FetchLike = async (url, init) => {
+    calls.push({ url, body: init.body });
+    const s = statuses[Math.min(i, statuses.length - 1)];
+    i += 1;
+    if (s === 'throw') throw new Error('rede caiu');
+    return { ok: s >= 200 && s < 300, status: s };
+  };
+  return { fetch, calls };
+}
+
+describe('postJson (entrega robusta)', () => {
+  it('sucesso na 1ª tentativa não faz retry', async () => {
+    const { fetch, calls } = recordingFetch([200]);
+    await postJson('https://x', { a: 1 }, { fetchImpl: fetch, sleep: noSleep });
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.body).toBe('{"a":1}');
+  });
+
+  it('tenta 1 retry e tem sucesso após falha transitória', async () => {
+    const { fetch, calls } = recordingFetch(['throw', 200]);
+    await postJson('https://x', {}, { fetchImpl: fetch, sleep: noSleep });
+    expect(calls).toHaveLength(2);
+  });
+
+  it('lança após as 2 tentativas falharem (HTTP 500)', async () => {
+    const { fetch, calls } = recordingFetch([500, 500]);
+    await expect(
+      postJson('https://x', {}, { fetchImpl: fetch, sleep: noSleep })
+    ).rejects.toThrow(/HTTP 500/);
+    expect(calls).toHaveLength(2);
+  });
+
+  it('respeita o timeout por tentativa', async () => {
+    const hang: FetchLike = () => new Promise(() => {}); // nunca resolve
+    await expect(
+      postJson('https://x', {}, { fetchImpl: hang, sleep: noSleep, timeoutMs: 5 })
+    ).rejects.toThrow(/timeout/);
+  });
+});
+
+describe('canais', () => {
+  it('DiscordChannel envia embed para a URL do webhook', async () => {
+    const { fetch, calls } = recordingFetch([204]);
+    await new DiscordChannel('https://discord/webhook', {
+      fetchImpl: fetch,
+      sleep: noSleep,
+    }).send(event);
+    expect(calls[0]!.url).toBe('https://discord/webhook');
+    expect(JSON.parse(calls[0]!.body)).toHaveProperty('embeds');
+  });
+
+  it('WebhookChannel envia o evento cru', async () => {
+    const { fetch, calls } = recordingFetch([200]);
+    await new WebhookChannel('https://meu/hook', {
+      fetchImpl: fetch,
+      sleep: noSleep,
+    }).send(event);
+    expect(JSON.parse(calls[0]!.body)).toMatchObject({ type: 'SERVICE_DOWN', serviceId: 'NFe:SP' });
+  });
+
+  it('TelegramChannel deriva a URL do token e inclui chat_id no corpo', async () => {
+    const { fetch, calls } = recordingFetch([200]);
+    await new TelegramChannel('BOT:TOKEN', '999', {
+      fetchImpl: fetch,
+      sleep: noSleep,
+    }).send(event);
+    expect(calls[0]!.url).toBe('https://api.telegram.org/botBOT:TOKEN/sendMessage');
+    expect(JSON.parse(calls[0]!.body).chat_id).toBe('999');
+  });
+});

--- a/packages/notifier/test/config.test.ts
+++ b/packages/notifier/test/config.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { parseNotifierConfig } from '../src/config.js';
+import { Notifier } from '../src/Notifier.js';
+import type { Channel } from '../src/channels/Channel.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+const ev = (type: NotificationEventDTO['type']): NotificationEventDTO => ({
+  type,
+  serviceId: 'NFe:SP',
+  occurredAt: AT,
+});
+
+describe('parseNotifierConfig', () => {
+  it('sem nenhuma var: nenhum canal (notifier vira no-op)', () => {
+    const cfg = parseNotifierConfig({});
+    expect(cfg.channels).toHaveLength(0);
+    expect(cfg.eventFilter).toBeNull();
+  });
+
+  it('ativa só os canais cujas vars existem', () => {
+    const cfg = parseNotifierConfig({
+      NOTIFY_DISCORD_WEBHOOK_URL: 'https://discord/x',
+      NOTIFY_WEBHOOK_URL: 'https://meu/hook',
+    });
+    expect(cfg.channels.map((c) => c.name).sort()).toEqual(['discord', 'webhook']);
+  });
+
+  it('Telegram exige token E chat_id (só um não ativa)', () => {
+    expect(parseNotifierConfig({ NOTIFY_TELEGRAM_BOT_TOKEN: 'T' }).channels).toHaveLength(0);
+    const cfg = parseNotifierConfig({
+      NOTIFY_TELEGRAM_BOT_TOKEN: 'T',
+      NOTIFY_TELEGRAM_CHAT_ID: '9',
+    });
+    expect(cfg.channels.map((c) => c.name)).toEqual(['telegram']);
+  });
+
+  it('NOTIFY_EVENTS vira filtro; ausente = todos (null)', () => {
+    expect(parseNotifierConfig({}).eventFilter).toBeNull();
+    const cfg = parseNotifierConfig({ NOTIFY_EVENTS: 'SERVICE_DOWN, CONTINGENCY_ENTERED' });
+    expect([...cfg.eventFilter!]).toEqual(['SERVICE_DOWN', 'CONTINGENCY_ENTERED']);
+  });
+});
+
+/** Canal fake que registra os eventos recebidos (ou falha, se `fail`). */
+function fakeChannel(name: string, received: NotificationEventDTO[], fail = false): Channel {
+  return {
+    name,
+    send: async (e) => {
+      if (fail) throw new Error(`${name} caiu`);
+      received.push(e);
+    },
+  };
+}
+
+describe('Notifier', () => {
+  it('sem canais: notify é no-op', async () => {
+    const n = new Notifier({ channels: [], eventFilter: null });
+    expect(n.enabled).toBe(false);
+    await expect(n.notify([ev('SERVICE_DOWN')])).resolves.toEqual({ sent: 0, failed: 0 });
+  });
+
+  it('faz fan-out eventos × canais', async () => {
+    const a: NotificationEventDTO[] = [];
+    const b: NotificationEventDTO[] = [];
+    const n = new Notifier({
+      channels: [fakeChannel('a', a), fakeChannel('b', b)],
+      eventFilter: null,
+    });
+    const res = await n.notify([ev('SERVICE_DOWN'), ev('SERVICE_RECOVERED')]);
+    expect(res).toEqual({ sent: 4, failed: 0 }); // 2 eventos × 2 canais
+    expect(a).toHaveLength(2);
+    expect(b).toHaveLength(2);
+  });
+
+  it('allSettled: um canal que falha não impede os demais', async () => {
+    const ok: NotificationEventDTO[] = [];
+    const n = new Notifier({
+      channels: [fakeChannel('bad', [], true), fakeChannel('ok', ok)],
+      eventFilter: null,
+    });
+    const res = await n.notify([ev('SERVICE_DOWN')]);
+    expect(res).toEqual({ sent: 1, failed: 1 });
+    expect(ok).toHaveLength(1); // o canal bom entregou apesar do outro falhar
+  });
+
+  it('aplica o filtro de tipos de evento', async () => {
+    const got: NotificationEventDTO[] = [];
+    const n = new Notifier({
+      channels: [fakeChannel('a', got)],
+      eventFilter: new Set(['SERVICE_DOWN']),
+    });
+    await n.notify([ev('SERVICE_DOWN'), ev('SERVICE_RECOVERED'), ev('DAILY_DIGEST')]);
+    expect(got.map((e) => e.type)).toEqual(['SERVICE_DOWN']);
+  });
+});

--- a/packages/notifier/test/diff.test.ts
+++ b/packages/notifier/test/diff.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DocumentType,
+  type ServiceStatusDTO,
+  type ServiceStateValue,
+} from '@monitor-sefaz/contracts';
+import { detectTransitions } from '../src/diff.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+
+/** Serviço mínimo para o diff (id estável document:uf). */
+function svc(uf: string, state: ServiceStateValue): ServiceStatusDTO {
+  return {
+    id: `NFe:${uf}`,
+    document: DocumentType.NFe,
+    uf,
+    authorizer: uf,
+    environment: 'production',
+    state,
+    cStat: null,
+    xMotivo: null,
+    latencyMs: 0,
+    source: 'svrs',
+    error: null,
+    checkedAt: AT,
+  };
+}
+
+const types = (prev: ServiceStatusDTO[], next: ServiceStatusDTO[]): string[] =>
+  detectTransitions(prev, next, AT).map((e) => e.type);
+
+describe('detectTransitions', () => {
+  it('baseline: serviço sem estado anterior não gera evento', () => {
+    expect(types([], [svc('SP', 'OPERATIONAL')])).toEqual([]);
+    expect(types([], [svc('SP', 'DOWN')])).toEqual([]); // nem quando começa DOWN
+  });
+
+  it('sem mudança de estado não gera evento', () => {
+    expect(types([svc('SP', 'OPERATIONAL')], [svc('SP', 'OPERATIONAL')])).toEqual([]);
+  });
+
+  it('OPERATIONAL → DOWN gera SERVICE_DOWN', () => {
+    expect(types([svc('SP', 'OPERATIONAL')], [svc('SP', 'DOWN')])).toEqual(['SERVICE_DOWN']);
+  });
+
+  it('DOWN → OPERATIONAL gera SERVICE_RECOVERED', () => {
+    expect(types([svc('SP', 'DOWN')], [svc('SP', 'OPERATIONAL')])).toEqual(['SERVICE_RECOVERED']);
+  });
+
+  it('ERROR conta como fora do ar: OPERATIONAL → ERROR gera SERVICE_DOWN', () => {
+    expect(types([svc('SP', 'OPERATIONAL')], [svc('SP', 'ERROR')])).toEqual(['SERVICE_DOWN']);
+  });
+
+  it('OPERATIONAL → CONTINGENCY: só CONTINGENCY_ENTERED (contingência é "no ar")', () => {
+    // isUp(CONTINGENCY)===true, então NÃO há SERVICE_DOWN aqui.
+    expect(types([svc('SP', 'OPERATIONAL')], [svc('SP', 'CONTINGENCY')])).toEqual([
+      'CONTINGENCY_ENTERED',
+    ]);
+  });
+
+  it('CONTINGENCY → OPERATIONAL: só CONTINGENCY_EXITED (segue no ar)', () => {
+    expect(types([svc('SP', 'CONTINGENCY')], [svc('SP', 'OPERATIONAL')])).toEqual([
+      'CONTINGENCY_EXITED',
+    ]);
+  });
+
+  it('DOWN → CONTINGENCY gera DOIS eventos ortogonais (RECOVERED + ENTERED)', () => {
+    // Voltou a operar (via SVC) E entrou em contingência — sinais independentes.
+    expect(types([svc('SP', 'DOWN')], [svc('SP', 'CONTINGENCY')])).toEqual([
+      'SERVICE_RECOVERED',
+      'CONTINGENCY_ENTERED',
+    ]);
+  });
+
+  it('CONTINGENCY → DOWN gera SERVICE_DOWN + CONTINGENCY_EXITED', () => {
+    expect(types([svc('SP', 'CONTINGENCY')], [svc('SP', 'DOWN')])).toEqual([
+      'SERVICE_DOWN',
+      'CONTINGENCY_EXITED',
+    ]);
+  });
+
+  it('preenche os campos do evento a partir do serviço atual', () => {
+    const prev = [svc('SP', 'OPERATIONAL')];
+    const next = [{ ...svc('SP', 'DOWN'), cStat: 109 }];
+    const [ev] = detectTransitions(prev, next, AT);
+    expect(ev).toMatchObject({
+      type: 'SERVICE_DOWN',
+      serviceId: 'NFe:SP',
+      uf: 'SP',
+      document: DocumentType.NFe,
+      previousState: 'OPERATIONAL',
+      currentState: 'DOWN',
+      cStat: 109,
+      occurredAt: AT,
+    });
+  });
+
+  it('processa vários serviços e ignora os que não mudaram', () => {
+    const prev = [svc('SP', 'OPERATIONAL'), svc('RJ', 'OPERATIONAL'), svc('MG', 'DOWN')];
+    const next = [svc('SP', 'DOWN'), svc('RJ', 'OPERATIONAL'), svc('MG', 'OPERATIONAL')];
+    const events = detectTransitions(prev, next, AT);
+    expect(events.map((e) => `${e.serviceId}:${e.type}`)).toEqual([
+      'NFe:SP:SERVICE_DOWN',
+      'NFe:MG:SERVICE_RECOVERED',
+    ]);
+  });
+});

--- a/packages/notifier/test/format.test.ts
+++ b/packages/notifier/test/format.test.ts
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import type { NotificationEventDTO } from '@monitor-sefaz/contracts';
+import { toDiscordPayload } from '../src/format/discord.js';
+import { toSlackPayload } from '../src/format/slack.js';
+import { toTelegramPayload } from '../src/format/telegram.js';
+
+const AT = '2026-07-10T00:00:00.000Z';
+
+const down: NotificationEventDTO = {
+  type: 'SERVICE_DOWN',
+  serviceId: 'NFe:SP',
+  uf: 'SP',
+  previousState: 'OPERATIONAL',
+  currentState: 'DOWN',
+  cStat: 109,
+  source: 'svrs',
+  occurredAt: AT,
+};
+
+const degraded: NotificationEventDTO = {
+  type: 'SOURCE_DEGRADED',
+  source: 'availability',
+  occurredAt: AT,
+};
+
+describe('formatters', () => {
+  describe('Discord', () => {
+    it('gera um embed com título, descrição, cor e timestamp', () => {
+      const p = toDiscordPayload(down);
+      expect(p.embeds).toHaveLength(1);
+      expect(p.embeds[0]!.title).toContain('fora do ar');
+      expect(p.embeds[0]!.description).toBe('NFe:SP: OPERATIONAL → DOWN');
+      expect(p.embeds[0]!.color).toBe(0xe4_3f_52); // vermelho DOWN
+      expect(p.embeds[0]!.timestamp).toBe(AT);
+      expect(p.embeds[0]!.footer?.text).toBe('fonte: svrs');
+    });
+
+    it('descreve SOURCE_DEGRADED pela fonte, sem exigir serviceId', () => {
+      const p = toDiscordPayload(degraded);
+      expect(p.embeds[0]!.description).toContain('availability');
+    });
+  });
+
+  describe('Slack', () => {
+    it('gera attachment com cor hex e ts em epoch', () => {
+      const p = toSlackPayload(down);
+      expect(p.attachments[0]!.color).toBe('#e43f52');
+      expect(p.attachments[0]!.text).toBe('NFe:SP: OPERATIONAL → DOWN');
+      expect(p.attachments[0]!.ts).toBe(Math.floor(Date.parse(AT) / 1000));
+    });
+  });
+
+  describe('Telegram', () => {
+    it('gera texto Markdown com chat_id', () => {
+      const p = toTelegramPayload(down, '12345');
+      expect(p.chat_id).toBe('12345');
+      expect(p.parse_mode).toBe('Markdown');
+      expect(p.text).toContain('*');
+      expect(p.text).toContain('NFe:SP: OPERATIONAL → DOWN');
+    });
+  });
+
+  it('cores diferem por tipo de evento (DOWN vermelho ≠ RECOVERED verde)', () => {
+    const recovered: NotificationEventDTO = { ...down, type: 'SERVICE_RECOVERED' };
+    expect(toDiscordPayload(down).embeds[0]!.color).not.toBe(
+      toDiscordPayload(recovered).embeds[0]!.color
+    );
+  });
+});

--- a/packages/notifier/test/format.test.ts
+++ b/packages/notifier/test/format.test.ts
@@ -66,4 +66,23 @@ describe('formatters', () => {
       toDiscordPayload(recovered).embeds[0]!.color
     );
   });
+
+  it('DAILY_DIGEST mostra os NÚMEROS do resumo (não só o título)', () => {
+    const digest: NotificationEventDTO = {
+      type: 'DAILY_DIGEST',
+      occurredAt: AT,
+      payload: { total: 135, operational: 130, availability: 96.3, degradedSources: ['availability'] },
+    };
+    const desc = toDiscordPayload(digest).embeds[0]!.description;
+    expect(desc).toContain('96.3%');
+    expect(desc).toContain('130/135');
+    expect(desc).toContain('availability'); // fonte degradada listada
+  });
+
+  it('Slack tolera occurredAt inválido (ts vira 0, não NaN)', () => {
+    const bad: NotificationEventDTO = { ...down, occurredAt: 'não-é-data' };
+    const p = toSlackPayload(bad);
+    expect(p.attachments[0]!.ts).toBe(0);
+    expect(Number.isNaN(p.attachments[0]!.ts)).toBe(false);
+  });
 });

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src"],
+  "references": [{ "path": "../contracts" }]
+}

--- a/packages/notifier/tsconfig.json
+++ b/packages/notifier/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "rootDir": "src",
-    "outDir": "dist"
+    "outDir": "dist",
+    "types": ["node"]
   },
   "include": ["src"],
   "references": [{ "path": "../contracts" }]

--- a/packages/notifier/vitest.config.ts
+++ b/packages/notifier/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['test/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       '@monitor-sefaz/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@monitor-sefaz/notifier':
+        specifier: workspace:*
+        version: link:../../packages/notifier
       axios:
         specifier: ^1.7.9
         version: 1.16.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@monitor-sefaz/core':
         specifier: workspace:*
         version: link:../../packages/core
+      '@monitor-sefaz/notifier':
+        specifier: workspace:*
+        version: link:../../packages/notifier
     devDependencies:
       '@types/node':
         specifier: ^22.10.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -222,6 +222,10 @@ importers:
       '@monitor-sefaz/contracts':
         specifier: workspace:*
         version: link:../contracts
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.19
 
 packages:
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
         specifier: ^22.10.2
         version: 22.19.19
 
+  packages/notifier:
+    dependencies:
+      '@monitor-sefaz/contracts':
+        specifier: workspace:*
+        version: link:../contracts
+
 packages:
 
   '@adobe/css-tools@4.5.0':

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -25,9 +25,11 @@
       "@monitor-sefaz/core": ["./packages/core/src/index.ts"],
       "@monitor-sefaz/catalog": ["./packages/catalog/src/index.ts"],
       "@monitor-sefaz/contracts": ["./packages/contracts/src/index.ts"],
+      "@monitor-sefaz/notifier": ["./packages/notifier/src/index.ts"],
       "@monitor-sefaz/core/*": ["./packages/core/src/*"],
       "@monitor-sefaz/catalog/*": ["./packages/catalog/src/*"],
-      "@monitor-sefaz/contracts/*": ["./packages/contracts/src/*"]
+      "@monitor-sefaz/contracts/*": ["./packages/contracts/src/*"],
+      "@monitor-sefaz/notifier/*": ["./packages/notifier/src/*"]
     }
   }
 }

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -5,4 +5,5 @@ export default defineWorkspace([
   'apps/api',
   'apps/web',
   'apps/worker',
+  'apps/collector',
 ]);

--- a/vitest.workspace.ts
+++ b/vitest.workspace.ts
@@ -4,4 +4,5 @@ export default defineWorkspace([
   'packages/*',
   'apps/api',
   'apps/web',
+  'apps/worker',
 ]);


### PR DESCRIPTION
PR consolidada com duas frentes de trabalho, verificada por auditoria exaustiva antes do merge. Substitui e engloba o #7 (endurecimento), que pode ser fechado.

## 1. Endurecimento do scraping (contra drift silencioso)

Torna observável a quebra que hoje é silenciosa quando a Receita/SVRS mudam o HTML.

- **retry** compartilhado (`core/domain/retry.ts`) aplicado também ao IntegraNotas.
- **paridade Node↔Worker**: `TextDecoder('latin1')` + backoff no `WorkerAvailabilityProvider`.
- **drift observável**: `ConsensusCollector.collectWithDiagnostics()` expõe cobertura + `degraded` por fonte no `summary.json` (bloco `sources`).
- **parser defensivo**: `AvailabilityParser` resolve colunas pelo cabeçalho (âncoras ASCII robustas ao mojibake), com índice fixo como fallback; layout irreconhecível esvazia a fonte (vira `degraded`) em vez de ler colunas erradas.

## 2. Sistema de notificações (webhooks por evento)

Novo pacote `packages/notifier`, plugado nas duas pontas (collector/Actions e API/Scheduler).

- **eventos** via `detectTransitions` (pura, reusa `isUp` — uma só semântica nas duas pontas): serviço caiu/voltou, entrou/saiu de contingência, `SOURCE_DEGRADED` (drift), `TECHNICAL_NOTE`, `DAILY_DIGEST`.
- **canais**: Discord/Slack/Telegram/webhook genérico, formatters desacoplados, entrega com timeout + 1 retry + `Promise.allSettled` (um canal falho não derruba os outros).
- **config por env** (`NOTIFY_*`): cada canal só ativa com suas vars; **sem env, tudo é no-op** — zero efeito no pipeline atual.
- **Notas Técnicas** (feature de coleta nova): raspa a lista do portal, deduplica em `technical-notes.json` versionado, emite `TECHNICAL_NOTE` por NT inédita.
- **resumo diário** `DAILY_DIGEST` opcional (`NOTIFY_DIGEST_HOUR`).

## Compatibilidade

Nenhuma assinatura pública muda; `collect()`, `AvailabilityProviderLike`, `AvailabilityParser.parse()` intactos. Campos novos no `summary.json` (`sources`) são opcionais. Sem `NOTIFY_*`, o comportamento é idêntico ao atual.

## Verificação (auditoria pré-merge)

- **199 testes** unit/integração verdes; typecheck 12/12; lint 8/8; build limpo.
- Dois auditores independentes varreram o diff. 5 achados de baixo risco corrigidos (try/catch na notificação, digest com números, Slack tolera data inválida, `prev` do Scheduler sem cStat enganoso, workflow passa `NOTIFY_*`). Falso-positivo de `degraded` na availability **descartado** (cobre os 135, deriva MDFe/DCe do SVRS).
- E2E real: collector dispara `SERVICE_RECOVERED` + `SOURCE_DEGRADED`; digest entrega `avail=100% op=135/135`; dedup de NT (3→0→1); guarda de piso preservada.

## Limitações conhecidas (conscientes, documentadas)

- Digest usa gatilho por hora sem estado; com o cron best-effort (~3h) pode duplicar/pular em dias atípicos.
- Serviço que **some** da coleta (fonte parou de publicar) não gera `SERVICE_DOWN` — evita falso-alarme em coleta parcial.