### PR TITLE
feat: digest idempotente + card de Notas Técnicas no dashboard

### DIFF
--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -16,6 +16,8 @@ import {
   type HistoryPointDTO,
   type ServiceStatusDTO,
   type SourceHealthDTO,
+  notifierStateSchema,
+  type NotifierStateDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
   type TechnicalNoteDTO,
@@ -25,7 +27,7 @@ import type { SourceHealth } from '@monitor-sefaz/core';
 import { Notifier, parseNotifierConfig } from '@monitor-sefaz/notifier';
 import { buildNotificationEvents } from './notifyEvents.js';
 import { reconcileTechnicalNotes, technicalNoteEvents } from './technicalNotes.js';
-import { buildDigestEvent, parseDigestHour } from './digest.js';
+import { buildDigestEvent, parseDigestHour, utcDate } from './digest.js';
 
 /** Retenção do histórico estático (ms). Padrão 7 dias. */
 const RETENTION_MS = Number(process.env.HISTORY_RETENTION_MS ?? 7 * 24 * 60 * 60 * 1000);
@@ -114,6 +116,17 @@ function loadTechnicalNotes(path: string): TechnicalNotesFileDTO {
     return technicalNotesFileSchema.parse(JSON.parse(readFileSync(path, 'utf8')));
   } catch {
     return { updatedAt: new Date(0).toISOString(), notes: [] };
+  }
+}
+
+function loadNotifierState(path: string): NotifierStateDTO {
+  if (!existsSync(path)) {
+    return { lastDigestDate: null };
+  }
+  try {
+    return notifierStateSchema.parse(JSON.parse(readFileSync(path, 'utf8')));
+  } catch {
+    return { lastDigestDate: null };
   }
 }
 
@@ -245,10 +258,14 @@ async function main(): Promise<void> {
     // (montagem de evento, entrega) NÃO deve marcar o job como vermelho nem
     // impedir a coleta — apenas registra o aviso.
     try {
+      const statePath = join(outDir, 'notifier-state.json');
+      const state = loadNotifierState(statePath);
+      const now = new Date(generatedAt);
       const digest = buildDigestEvent(
         summary,
         parseDigestHour(process.env.NOTIFY_DIGEST_HOUR),
-        new Date(generatedAt)
+        now,
+        state.lastDigestDate
       );
       const events = [
         ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
@@ -257,6 +274,13 @@ async function main(): Promise<void> {
       ];
       const { sent, failed } = await notifier.notify(events);
       console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
+      // Marca o digest do dia como enviado (idempotência), só após tentar entregar.
+      if (digest) {
+        writeFileSync(
+          statePath,
+          JSON.stringify({ ...state, lastDigestDate: utcDate(now) }, null, 2)
+        );
+      }
     } catch (err) {
       console.warn(`Notificação falhou (coleta preservada): ${err instanceof Error ? err.message : err}`);
     }

--- a/apps/collector/src/collect.ts
+++ b/apps/collector/src/collect.ts
@@ -261,25 +261,34 @@ async function main(): Promise<void> {
       const statePath = join(outDir, 'notifier-state.json');
       const state = loadNotifierState(statePath);
       const now = new Date(generatedAt);
+      const events = [
+        ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
+        ...technicalNoteEvents(freshNotes, generatedAt),
+      ];
+      const { sent, failed } = await notifier.notify(events);
+      console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
+
+      // Digest enviado SEPARADAMENTE para saber se ELE foi de fato entregue: só
+      // então marcamos o dia como concluído. Isso evita "perder" o digest quando
+      // nenhum canal entregou (rede caiu) ou quando NOTIFY_EVENTS o filtra — nesses
+      // casos `digestSent === 0` e o state não avança, então uma próxima rodada do
+      // mesmo dia tenta de novo.
       const digest = buildDigestEvent(
         summary,
         parseDigestHour(process.env.NOTIFY_DIGEST_HOUR),
         now,
         state.lastDigestDate
       );
-      const events = [
-        ...buildNotificationEvents(previousHistory, services, summary.sources, generatedAt),
-        ...technicalNoteEvents(freshNotes, generatedAt),
-        ...(digest ? [digest] : []),
-      ];
-      const { sent, failed } = await notifier.notify(events);
-      console.log(`Notificações: ${events.length} eventos, ${sent} entregues, ${failed} falharam`);
-      // Marca o digest do dia como enviado (idempotência), só após tentar entregar.
       if (digest) {
-        writeFileSync(
-          statePath,
-          JSON.stringify({ ...state, lastDigestDate: utcDate(now) }, null, 2)
-        );
+        const { sent: digestSent } = await notifier.notify([digest]);
+        if (digestSent > 0) {
+          writeFileSync(
+            statePath,
+            JSON.stringify({ ...state, lastDigestDate: utcDate(now) }, null, 2)
+          );
+        } else {
+          console.warn('Digest não entregue a nenhum canal; não marcado como enviado (tentará de novo).');
+        }
       }
     } catch (err) {
       console.warn(`Notificação falhou (coleta preservada): ${err instanceof Error ? err.message : err}`);

--- a/apps/collector/src/digest.ts
+++ b/apps/collector/src/digest.ts
@@ -1,20 +1,30 @@
 import type { NotificationEventDTO, SummaryDTO } from '@monitor-sefaz/contracts';
 
+/** Data UTC no formato YYYY-MM-DD (dia do último digest enviado). */
+export function utcDate(now: Date): string {
+  return now.toISOString().slice(0, 10);
+}
+
 /**
- * Decide se esta rodada deve emitir o resumo diário e, em caso afirmativo, monta o
- * evento DAILY_DIGEST a partir do summary. Função PURA (recebe a hora atual).
+ * Decide se esta rodada deve emitir o resumo diário e monta o evento DAILY_DIGEST.
+ * Função PURA (recebe a hora atual e a data do último digest).
  *
- * Gatilho SEM estado: o Actions roda de hora em hora, então emitimos o digest
- * apenas quando a hora UTC atual == `targetHour`. `targetHour` vem de
- * NOTIFY_DIGEST_HOUR (0–23); ausente/ inválido = digest desligado (retorna null).
- * Isso evita persistir "já enviei hoje" — a granularidade horária do cron basta.
+ * Gatilho IDEMPOTENTE por dia, robusto ao cron best-effort (~3h, irregular):
+ * emite quando a hora UTC atual é >= `targetHour` E ainda não houve digest hoje
+ * (`lastDigestDate !== hoje`). Assim:
+ * - se o cron PULAR a hora-alvo exata, o digest ainda sai na próxima rodada do dia;
+ * - se o cron rodar VÁRIAS vezes após a hora-alvo, só o primeiro do dia dispara.
+ * `targetHour` vem de NOTIFY_DIGEST_HOUR (0–23); ausente/inválido = desligado.
  */
 export function buildDigestEvent(
   summary: SummaryDTO,
   targetHour: number | null,
-  now: Date
+  now: Date,
+  lastDigestDate: string | null
 ): NotificationEventDTO | null {
-  if (targetHour === null || now.getUTCHours() !== targetHour) {
+  if (targetHour === null) return null;
+  const today = utcDate(now);
+  if (now.getUTCHours() < targetHour || lastDigestDate === today) {
     return null;
   }
   return {

--- a/apps/collector/test/digest.test.ts
+++ b/apps/collector/test/digest.test.ts
@@ -32,31 +32,41 @@ describe('parseDigestHour', () => {
   });
 });
 
-describe('buildDigestEvent', () => {
-  it('emite DAILY_DIGEST quando a hora UTC bate a hora-alvo', () => {
-    const ev = buildDigestEvent(summary, 8, new Date('2026-07-10T08:17:00.000Z'));
+describe('buildDigestEvent (idempotente por dia)', () => {
+  it('emite na hora-alvo quando ainda não houve digest hoje', () => {
+    const ev = buildDigestEvent(summary, 8, new Date('2026-07-10T08:17:00.000Z'), null);
     expect(ev).not.toBeNull();
     expect(ev!.type).toBe('DAILY_DIGEST');
     expect(ev!.payload).toMatchObject({
       total: 135,
       operational: 130,
-      failing: 5,
       availability: 96.3,
       degradedSources: ['availability'],
     });
   });
 
-  it('não emite fora da hora-alvo', () => {
-    expect(buildDigestEvent(summary, 8, new Date('2026-07-10T09:00:00.000Z'))).toBeNull();
+  it('emite mesmo APÓS a hora-alvo (cron pulou a hora exata) se não enviou hoje', () => {
+    // hora 11 > alvo 8, lastDigestDate de ontem → ainda deve sair (resolve o "pulo")
+    const ev = buildDigestEvent(summary, 8, new Date('2026-07-10T11:00:00.000Z'), '2026-07-09');
+    expect(ev).not.toBeNull();
+  });
+
+  it('NÃO reemite no mesmo dia (resolve a duplicação)', () => {
+    const ev = buildDigestEvent(summary, 8, new Date('2026-07-10T09:00:00.000Z'), '2026-07-10');
+    expect(ev).toBeNull();
+  });
+
+  it('não emite ANTES da hora-alvo', () => {
+    expect(buildDigestEvent(summary, 8, new Date('2026-07-10T07:59:00.000Z'), null)).toBeNull();
   });
 
   it('não emite quando desligado (targetHour null)', () => {
-    expect(buildDigestEvent(summary, null, new Date('2026-07-10T08:00:00.000Z'))).toBeNull();
+    expect(buildDigestEvent(summary, null, new Date('2026-07-10T08:00:00.000Z'), null)).toBeNull();
   });
 
-  it('degradedSources vazio quando não há sources ou nenhuma degradada', () => {
+  it('degradedSources vazio quando não há sources', () => {
     const clean = { ...summary, sources: undefined };
-    const ev = buildDigestEvent(clean, 8, new Date('2026-07-10T08:00:00.000Z'));
+    const ev = buildDigestEvent(clean, 8, new Date('2026-07-10T08:00:00.000Z'), null);
     expect(ev!.payload!.degradedSources).toEqual([]);
   });
 });

--- a/apps/web/public/data/notifier-state.json
+++ b/apps/web/public/data/notifier-state.json
@@ -1,0 +1,3 @@
+{
+  "lastDigestDate": null
+}

--- a/apps/web/src/api/ApiDataSource.ts
+++ b/apps/web/src/api/ApiDataSource.ts
@@ -6,6 +6,7 @@ import {
   type HistoryResponseDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
+  type TechnicalNotesFileDTO,
 } from '@monitor-sefaz/contracts';
 import {
   fetchJson,
@@ -55,5 +56,14 @@ export class ApiDataSource implements DataSource {
    */
   public async getHistorySeries(): Promise<HistorySeries> {
     return {};
+  }
+
+  /**
+   * Como as séries: a API/Worker não serve as Notas Técnicas (é conteúdo estático
+   * versionado). No modo híbrido o `HybridDataSource` delega isto ao estático;
+   * aqui retornamos vazio para o modo self-host puro.
+   */
+  public async getTechnicalNotes(): Promise<TechnicalNotesFileDTO> {
+    return { updatedAt: new Date(0).toISOString(), notes: [] };
   }
 }

--- a/apps/web/src/api/DataSource.ts
+++ b/apps/web/src/api/DataSource.ts
@@ -5,6 +5,7 @@ import {
   type HistoryResponseDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
+  type TechnicalNotesFileDTO,
 } from '@monitor-sefaz/contracts';
 
 /** Mapa `id do serviço` → série de pontos, usado para os sparklines dos cards. */
@@ -28,6 +29,8 @@ export interface DataSource {
   getHistory(id: string, period: HistoryPeriod): Promise<HistoryResponseDTO>;
   /** Todas as séries de uma vez (para os sparklines dos cards). */
   getHistorySeries(): Promise<HistorySeries>;
+  /** Notas Técnicas publicadas no portal (conteúdo estático versionado). */
+  getTechnicalNotes(): Promise<TechnicalNotesFileDTO>;
 }
 
 export async function fetchJson(url: string): Promise<unknown> {

--- a/apps/web/src/api/HybridDataSource.ts
+++ b/apps/web/src/api/HybridDataSource.ts
@@ -3,6 +3,7 @@ import type {
   HistoryResponseDTO,
   StatusSnapshotDTO,
   SummaryDTO,
+  TechnicalNotesFileDTO,
 } from '@monitor-sefaz/contracts';
 import type { DataSource, HistorySeries, StatusFilters } from './DataSource.js';
 
@@ -46,5 +47,10 @@ export class HybridDataSource implements DataSource {
 
   public getHistorySeries(): Promise<HistorySeries> {
     return this.history.getHistorySeries();
+  }
+
+  public getTechnicalNotes(): Promise<TechnicalNotesFileDTO> {
+    // Conteúdo estático (como o histórico) — delega à fonte versionada.
+    return this.history.getTechnicalNotes();
   }
 }

--- a/apps/web/src/api/StaticDataSource.ts
+++ b/apps/web/src/api/StaticDataSource.ts
@@ -1,10 +1,12 @@
 import {
   historyFileSchema,
   summarySchema,
+  technicalNotesFileSchema,
   type HistoryPeriod,
   type HistoryResponseDTO,
   type StatusSnapshotDTO,
   type SummaryDTO,
+  type TechnicalNotesFileDTO,
 } from '@monitor-sefaz/contracts';
 import {
   fetchJson,
@@ -58,5 +60,18 @@ export class StaticDataSource implements DataSource {
   public async getHistorySeries(): Promise<HistorySeries> {
     const file = historyFileSchema.parse(await fetchJson(`${this.base}data/history.json`));
     return file.series;
+  }
+
+  public async getTechnicalNotes(): Promise<TechnicalNotesFileDTO> {
+    // Tolerante: o technical-notes.json só existe depois que a coleta de NTs
+    // roda com sucesso. Se faltar (404) ou vier inválido, devolve vazio em vez
+    // de derrubar o dashboard — a seção simplesmente não aparece.
+    try {
+      return technicalNotesFileSchema.parse(
+        await fetchJson(`${this.base}data/technical-notes.json`)
+      );
+    } catch {
+      return { updatedAt: new Date(0).toISOString(), notes: [] };
+    }
   }
 }

--- a/apps/web/src/components/TechnicalNotesCard.tsx
+++ b/apps/web/src/components/TechnicalNotesCard.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { ChevronDown, FileText, ExternalLink } from 'lucide-react';
+import type { TechnicalNoteDTO } from '@monitor-sefaz/contracts';
+
+interface Props {
+  notes: TechnicalNoteDTO[];
+  /** Quantas notas mostrar colapsado antes de "ver todas". */
+  readonly previewCount?: number;
+}
+
+/**
+ * Seção colapsável com as Notas Técnicas publicadas no portal da NF-e. Prop-driven
+ * (a página injeta os dados do hook) para ser trivial de testar. Não renderiza
+ * nada quando não há notas — a seção só aparece quando há conteúdo.
+ */
+export function TechnicalNotesCard({ notes, previewCount = 5 }: Props) {
+  const [open, setOpen] = useState(false);
+
+  if (notes.length === 0) {
+    return null;
+  }
+
+  // Colapsado mostra as `previewCount` mais recentes (a coleta preserva a ordem
+  // do portal, mais novas primeiro); aberto mostra todas.
+  const visible = open ? notes : notes.slice(0, previewCount);
+
+  return (
+    <section
+      className="rounded-xl border"
+      style={{ background: 'var(--surface)', boxShadow: 'var(--shadow)' }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        className="flex w-full items-center justify-between gap-2 p-4 text-left"
+      >
+        <span className="flex items-center gap-2 text-sm font-semibold">
+          <FileText className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+          Notas Técnicas ({notes.length})
+        </span>
+        {notes.length > previewCount && (
+          <ChevronDown
+            className="h-4 w-4 transition-transform"
+            style={{ transform: open ? 'rotate(180deg)' : 'none', color: 'var(--text-dim)' }}
+          />
+        )}
+      </button>
+
+      <ul className="flex flex-col gap-3 border-t px-4 py-4">
+        {visible.map((note) => (
+          <li key={`${note.title}|${note.link ?? ''}`} className="text-sm leading-relaxed">
+            {note.link ? (
+              <a
+                href={note.link}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex items-center gap-1 hover:underline"
+                style={{ color: 'var(--accent)' }}
+              >
+                {note.title}
+                <ExternalLink className="h-3 w-3 shrink-0" />
+              </a>
+            ) : (
+              <span>{note.title}</span>
+            )}
+          </li>
+        ))}
+      </ul>
+    </section>
+  );
+}

--- a/apps/web/src/components/TechnicalNotesCard.tsx
+++ b/apps/web/src/components/TechnicalNotesCard.tsx
@@ -20,36 +20,50 @@ export function TechnicalNotesCard({ notes, previewCount = 5 }: Props) {
     return null;
   }
 
-  // Colapsado mostra as `previewCount` mais recentes (a coleta preserva a ordem
-  // do portal, mais novas primeiro); aberto mostra todas.
-  const visible = open ? notes : notes.slice(0, previewCount);
+  // Só é colapsável quando há mais notas que o preview. Caso contrário o header
+  // é estático (sem botão/aria-expanded, que seriam enganosos sem nada a expandir).
+  const collapsible = notes.length > previewCount;
+  const visible = collapsible && !open ? notes.slice(0, previewCount) : notes;
+
+  const headerContent = (
+    <>
+      <span className="flex items-center gap-2 text-sm font-semibold">
+        <FileText className="h-4 w-4" style={{ color: 'var(--accent)' }} />
+        Notas Técnicas ({notes.length})
+      </span>
+      {collapsible && (
+        <ChevronDown
+          className="h-4 w-4 transition-transform"
+          style={{ transform: open ? 'rotate(180deg)' : 'none', color: 'var(--text-dim)' }}
+        />
+      )}
+    </>
+  );
 
   return (
     <section
       className="rounded-xl border"
       style={{ background: 'var(--surface)', boxShadow: 'var(--shadow)' }}
     >
-      <button
-        type="button"
-        onClick={() => setOpen((v) => !v)}
-        aria-expanded={open}
-        className="flex w-full items-center justify-between gap-2 p-4 text-left"
-      >
-        <span className="flex items-center gap-2 text-sm font-semibold">
-          <FileText className="h-4 w-4" style={{ color: 'var(--accent)' }} />
-          Notas Técnicas ({notes.length})
-        </span>
-        {notes.length > previewCount && (
-          <ChevronDown
-            className="h-4 w-4 transition-transform"
-            style={{ transform: open ? 'rotate(180deg)' : 'none', color: 'var(--text-dim)' }}
-          />
-        )}
-      </button>
+      {collapsible ? (
+        <button
+          type="button"
+          onClick={() => setOpen((v) => !v)}
+          aria-expanded={open}
+          className="flex w-full items-center justify-between gap-2 p-4 text-left"
+        >
+          {headerContent}
+        </button>
+      ) : (
+        <div className="flex w-full items-center justify-between gap-2 p-4">{headerContent}</div>
+      )}
 
       <ul className="flex flex-col gap-3 border-t px-4 py-4">
-        {visible.map((note) => (
-          <li key={`${note.title}|${note.link ?? ''}`} className="text-sm leading-relaxed">
+        {visible.map((note, i) => (
+          <li
+            key={`${note.firstSeenAt}|${note.title}|${i}`}
+            className="text-sm leading-relaxed"
+          >
             {note.link ? (
               <a
                 href={note.link}

--- a/apps/web/src/hooks/useStatus.ts
+++ b/apps/web/src/hooks/useStatus.ts
@@ -41,3 +41,13 @@ export function useHistorySeries() {
     staleTime: POLL_INTERVAL_MS,
   });
 }
+
+/** Notas Técnicas do portal. Mudam raramente → polling lento. */
+export function useTechnicalNotes() {
+  return useQuery({
+    queryKey: ['technical-notes'],
+    queryFn: () => dataSource.getTechnicalNotes(),
+    refetchInterval: POLL_INTERVAL_MS * 5,
+    staleTime: POLL_INTERVAL_MS,
+  });
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import {
   useHistorySeries,
   useStatusSnapshot,
   useSummary,
+  useTechnicalNotes,
   POLL_INTERVAL_MS,
 } from '../hooks/useStatus.js';
 import { useTheme } from '../hooks/useTheme.js';
@@ -19,6 +20,7 @@ import { Footer } from '../components/Footer.js';
 import { StatusLegend } from '../components/StatusLegend.js';
 import { BrazilMap } from '../components/BrazilMap.js';
 import { HelpSection } from '../components/HelpSection.js';
+import { TechnicalNotesCard } from '../components/TechnicalNotesCard.js';
 import { STATE_SEVERITY } from '../components/serviceState.js';
 
 /** Estado agregado (pior) de uma UF entre os serviços visíveis — colore o chip. */
@@ -52,6 +54,7 @@ export function DashboardPage() {
   const status = useStatusSnapshot(refresh);
   const summary = useSummary(refresh);
   const series = useHistorySeries();
+  const technicalNotes = useTechnicalNotes();
 
   const all = status.data?.services ?? [];
 
@@ -154,6 +157,7 @@ export function DashboardPage() {
           <ServiceGrid services={visible} series={series.data ?? {}} onSelect={setSelected} />
         )}
 
+        <TechnicalNotesCard notes={technicalNotes.data?.notes ?? []} />
         <HelpSection />
       </main>
 

--- a/apps/web/test/TechnicalNotesCard.test.tsx
+++ b/apps/web/test/TechnicalNotesCard.test.tsx
@@ -40,4 +40,22 @@ describe('TechnicalNotesCard', () => {
     fireEvent.click(screen.getByRole('button'));
     expect(screen.getByText('NT-5')).toBeInTheDocument();
   });
+
+  it('não vira botão quando cabe no preview (sem controle interativo enganoso)', () => {
+    render(<TechnicalNotesCard notes={[note('NT-a'), note('NT-b')]} previewCount={5} />);
+    // 2 notas <= previewCount 5: header estático, sem role=button nem aria-expanded
+    expect(screen.queryByRole('button')).toBeNull();
+    expect(screen.getByText('NT-a')).toBeInTheDocument();
+    expect(screen.getByText('NT-b')).toBeInTheDocument();
+  });
+
+  it('notas de mesmo título e sem link não colidem (keys distintas por firstSeenAt+índice)', () => {
+    // Duas NTs idênticas em título e link: não deve dar warning de key nem sumir uma.
+    const dup: TechnicalNoteDTO[] = [
+      { title: 'NT igual', link: null, firstSeenAt: '2026-07-10T00:00:00.000Z' },
+      { title: 'NT igual', link: null, firstSeenAt: '2026-07-10T00:00:00.000Z' },
+    ];
+    render(<TechnicalNotesCard notes={dup} />);
+    expect(screen.getAllByText('NT igual')).toHaveLength(2);
+  });
 });

--- a/apps/web/test/TechnicalNotesCard.test.tsx
+++ b/apps/web/test/TechnicalNotesCard.test.tsx
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import type { TechnicalNoteDTO } from '@monitor-sefaz/contracts';
+import { TechnicalNotesCard } from '../src/components/TechnicalNotesCard.js';
+
+const note = (title: string, link: string | null = null): TechnicalNoteDTO => ({
+  title,
+  link,
+  firstSeenAt: '2026-07-10T00:00:00.000Z',
+});
+
+describe('TechnicalNotesCard', () => {
+  it('não renderiza nada quando não há notas', () => {
+    const { container } = render(<TechnicalNotesCard notes={[]} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renderiza o título e a contagem', () => {
+    render(<TechnicalNotesCard notes={[note('NT 2024.001'), note('NT 2023.004')]} />);
+    expect(screen.getByText('Notas Técnicas (2)')).toBeInTheDocument();
+    expect(screen.getByText('NT 2024.001')).toBeInTheDocument();
+  });
+
+  it('nota com link vira âncora (target=_blank); sem link vira texto', () => {
+    render(<TechnicalNotesCard notes={[note('Com link', 'https://x/nt'), note('Sem link', null)]} />);
+    const anchor = screen.getByText('Com link').closest('a');
+    expect(anchor).toHaveAttribute('href', 'https://x/nt');
+    expect(anchor).toHaveAttribute('target', '_blank');
+    // "Sem link" não é âncora
+    expect(screen.getByText('Sem link').closest('a')).toBeNull();
+  });
+
+  it('colapsa: mostra só previewCount até expandir', () => {
+    const notes = Array.from({ length: 8 }, (_, i) => note(`NT-${i}`));
+    render(<TechnicalNotesCard notes={notes} previewCount={3} />);
+    // colapsado: 3 visíveis, NT-3 ainda não
+    expect(screen.getByText('NT-2')).toBeInTheDocument();
+    expect(screen.queryByText('NT-5')).not.toBeInTheDocument();
+    // expande
+    fireEvent.click(screen.getByRole('button'));
+    expect(screen.getByText('NT-5')).toBeInTheDocument();
+  });
+});

--- a/packages/contracts/src/schemas.ts
+++ b/packages/contracts/src/schemas.ts
@@ -196,6 +196,16 @@ export const technicalNotesFileSchema = z.object({
 });
 export type TechnicalNotesFileDTO = z.infer<typeof technicalNotesFileSchema>;
 
+/**
+ * Estado persistido do notificador entre execuções do collector (versionado).
+ * Hoje guarda só a data (YYYY-MM-DD UTC) do último resumo diário enviado, para
+ * o digest ser idempotente por dia mesmo com o cron irregular do Actions.
+ */
+export const notifierStateSchema = z.object({
+  lastDigestDate: z.string().nullable(),
+});
+export type NotifierStateDTO = z.infer<typeof notifierStateSchema>;
+
 /** Períodos suportados pela consulta de histórico curto. */
 // '1h'/'6h' foram removidos: com a cadência real de coleta (~3h/ponto) rendem
 // 0–2 amostras, deixando gráfico vazio e uptime sobre amostra única.

--- a/packages/notifier/src/diff.ts
+++ b/packages/notifier/src/diff.ts
@@ -39,6 +39,11 @@ export function detectTransitions(
   const prevById = new Map(prev.map((s) => [s.id, s]));
   const events: NotificationEventDTO[] = [];
 
+  // NOTA DE DESIGN — serviço que SOME de `next` (estava em `prev`, sumiu agora):
+  // deliberadamente NÃO gera evento. Tratá-lo como SERVICE_DOWN seria falso-alarme
+  // em coleta parcial (uma fonte deixou de cobrir aquela UF). E o caso real de
+  // "todas as fontes pararam de cobrir" já é sinalizado pelo SOURCE_DEGRADED do
+  // consenso (Fase 8). Iterar só `next` é, portanto, correto — não uma lacuna.
   for (const cur of next) {
     const before = prevById.get(cur.id);
     if (!before) {


### PR DESCRIPTION
Empilhada sobre o #8 (base `feat/notifier-digest`). Dois refinamentos após a auditoria do sistema de notificação.

## 1. Digest idempotente por dia (resolve limitação conhecida)

O gatilho do resumo diário passa de "hora UTC == alvo" para **"hora >= alvo E ainda não enviou hoje"**, com a data do último envio persistida em `notifier-state.json` (novo `notifierStateSchema`). Robusto ao cron best-effort (~3h, irregular):
- **não duplica** — só o primeiro digest do dia dispara;
- **não pula** — se o cron perder a hora exata, o digest sai na próxima rodada do dia.

## 2. Sumiço de serviço: documentado como decisão

Um serviço que some da coleta **não** vira `SERVICE_DOWN` (seria falso-alarme em coleta parcial; o caso real já é coberto por `SOURCE_DEGRADED`). Documentado em `diff.ts` — é design, não lacuna.

## 3. Card de Notas Técnicas no dashboard

A Fase 6 já coletava as NTs (`technical-notes.json`); agora elas aparecem no painel.
- `getTechnicalNotes` nas 3 DataSources — estático lê de forma **tolerante** (404/inválido → seção não aparece); Hybrid delega ao estático; Api stub vazio.
- `useTechnicalNotes` (react-query, polling lento).
- `TechnicalNotesCard`: seção colapsável (espelha `HelpSection`), links externos quando houver; não renderiza nada sem notas.

## Verificação

- Testes: web 17 (+4 do card), collector 18 (+2 do digest); typecheck 12/12; lint 8/8; build do web verde.
- E2E: 2 coletas no mesmo dia → **exatamente 1 digest** (`notifier-state.json` persistido com `lastDigestDate`).