### PR TITLE
ci: guard de drift ao vivo (MONITOR-6)

### DIFF
--- a/.github/workflows/drift-check.yml
+++ b/.github/workflows/drift-check.yml
@@ -1,0 +1,50 @@
+name: Guard de drift (fontes ao vivo)
+
+# Health-check do PARSER contra o HTML REAL do portal. As fixtures dos testes são
+# estáticas e não pegam quando a SEFAZ muda o layout; este job faz uma coleta ao
+# vivo (1 fetch por fonte) e avisa se alguma fonte OFICIAL cair abaixo do piso de
+# cobertura — sinal de que o parser parou de casar (drift).
+#
+# É NON-BLOCKING e SEPARADO do pipeline: não roda no push nem antes do deploy, e
+# uma falha aqui não impede coleta nem publicação. Só sinaliza (anotação + run
+# vermelho opcional) para o mantenedor investigar.
+on:
+  schedule:
+    # 1x/dia (06:23 UTC). Não precisa de mais — drift de layout é raro e o objetivo
+    # é detecção, não monitoramento contínuo. Minuto quebrado evita a hora cheia.
+    - cron: '23 6 * * *'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: drift-check
+  cancel-in-progress: true
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+
+      # continue-on-error: o resultado é capturado no id do step; o job não é
+      # abortado por um drift. A conclusão do step (success/failure) fica visível.
+      - name: Verificar drift ao vivo
+        id: drift
+        continue-on-error: true
+        run: pnpm --filter @monitor-sefaz/collector drift-check
+
+      - name: Anotar quando houver drift
+        if: steps.drift.outcome == 'failure'
+        run: |
+          echo "::warning title=Drift detectado::Uma fonte oficial veio abaixo do piso de cobertura na coleta ao vivo. Provável mudança de HTML do portal — verifique os parsers (veja o log do passo anterior)."
+          # Marca o job como falho para o run aparecer vermelho (visibilidade),
+          # sem afetar coleta/deploy (workflows independentes).
+          exit 1

--- a/apps/collector/package.json
+++ b/apps/collector/package.json
@@ -7,7 +7,8 @@
     "typecheck": "tsc -b tsconfig.json",
     "lint": "eslint src",
     "test": "vitest run --passWithNoTests",
-    "collect": "tsx src/collect.ts"
+    "collect": "tsx src/collect.ts",
+    "drift-check": "tsx src/drift-check.ts"
   },
   "dependencies": {
     "@monitor-sefaz/catalog": "workspace:*",

--- a/apps/collector/src/drift-check.ts
+++ b/apps/collector/src/drift-check.ts
@@ -1,0 +1,35 @@
+import { ConsensusCollector } from '@monitor-sefaz/core';
+import { Catalog, DEFAULT_MIN_COVERAGE_RATIO } from '@monitor-sefaz/catalog';
+import { evaluateDrift } from './driftCheck.js';
+
+/**
+ * Guard de drift AO VIVO. Faz uma coleta real (1 fetch por fonte), avalia a saúde
+ * por fonte e reporta se alguma fonte OFICIAL veio degradada — o drift de HTML do
+ * portal que as fixtures estáticas não pegam.
+ *
+ * Sai com código 1 quando detecta drift, para o workflow poder sinalizar. O
+ * workflow que o invoca é NON-BLOCKING (continue-on-error), separado do pipeline
+ * de coleta/deploy — este check nunca deve derrubar a publicação.
+ */
+async function main(): Promise<void> {
+  const ratio = Number(process.env.MIN_COVERAGE_RATIO ?? DEFAULT_MIN_COVERAGE_RATIO);
+  const collector = ConsensusCollector.createForNode(new Catalog(), ratio);
+  const { sources } = await collector.collectWithDiagnostics();
+
+  const report = evaluateDrift(sources);
+  console.log('Diagnóstico de cobertura por fonte (coleta ao vivo):');
+  for (const line of report.lines) {
+    console.log(line);
+  }
+
+  if (report.drift) {
+    console.error(
+      `\n⚠️  DRIFT: fonte(s) oficial(is) degradada(s): ${report.degradedOfficial.join(', ')}.` +
+        ` Provável mudança de HTML do portal — verifique os parsers.`
+    );
+    process.exit(1);
+  }
+  console.log('\n✅ Sem drift: todas as fontes oficiais acima do piso de cobertura.');
+}
+
+void main();

--- a/apps/collector/src/driftCheck.ts
+++ b/apps/collector/src/driftCheck.ts
@@ -1,0 +1,33 @@
+import type { SourceHealth } from '@monitor-sefaz/core';
+
+/** Resultado da avaliação de drift a partir da saúde por fonte. */
+export interface DriftReport {
+  /** Há drift? (ao menos uma fonte OFICIAL degradada.) */
+  readonly drift: boolean;
+  /** Nomes das fontes oficiais degradadas. */
+  readonly degradedOfficial: string[];
+  /** Linhas legíveis por fonte, para o log do CI. */
+  readonly lines: string[];
+}
+
+/**
+ * Avalia o diagnóstico por fonte de uma coleta AO VIVO e decide se há drift.
+ * Função PURA. Drift = alguma fonte OFICIAL veio degradada (cobertura abaixo do
+ * piso) — o sinal de que o portal mudou o HTML e o parser parou de casar, que as
+ * fixtures estáticas não pegam. Fontes não-oficiais degradadas não contam
+ * (o consenso não depende delas para o estado).
+ */
+export function evaluateDrift(sources: readonly SourceHealth[]): DriftReport {
+  const degradedOfficial = sources
+    .filter((s) => s.official && s.degraded)
+    .map((s) => s.source);
+
+  const lines = sources.map(
+    (s) =>
+      `  ${s.official ? '[oficial]' : '[terceiro]'} ${s.source}: ` +
+      `${s.collected}/${s.expected} (${Math.round(s.coverage * 100)}%)` +
+      `${s.degraded ? ' — DEGRADADA' : ''}`
+  );
+
+  return { drift: degradedOfficial.length > 0, degradedOfficial, lines };
+}

--- a/apps/collector/test/driftCheck.test.ts
+++ b/apps/collector/test/driftCheck.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import type { SourceHealth } from '@monitor-sefaz/core';
+import { evaluateDrift } from '../src/driftCheck.js';
+
+const src = (
+  source: string,
+  official: boolean,
+  degraded: boolean
+): SourceHealth => ({
+  source,
+  official,
+  collected: degraded ? 3 : 130,
+  expected: 135,
+  coverage: degraded ? 0.022 : 0.963,
+  degraded,
+});
+
+describe('evaluateDrift', () => {
+  it('sem drift quando todas as fontes oficiais estão acima do piso', () => {
+    const r = evaluateDrift([
+      src('svrs', true, false),
+      src('availability', true, false),
+      src('integranotas', false, false),
+    ]);
+    expect(r.drift).toBe(false);
+    expect(r.degradedOfficial).toEqual([]);
+  });
+
+  it('drift quando uma fonte OFICIAL está degradada', () => {
+    const r = evaluateDrift([
+      src('svrs', true, false),
+      src('availability', true, true), // Receita mudou o HTML → degradada
+      src('integranotas', false, false),
+    ]);
+    expect(r.drift).toBe(true);
+    expect(r.degradedOfficial).toEqual(['availability']);
+  });
+
+  it('terceiro (não-oficial) degradado NÃO conta como drift', () => {
+    const r = evaluateDrift([
+      src('svrs', true, false),
+      src('availability', true, false),
+      src('integranotas', false, true), // não-oficial caiu — irrelevante para o guard
+    ]);
+    expect(r.drift).toBe(false);
+    expect(r.degradedOfficial).toEqual([]);
+  });
+
+  it('inclui uma linha legível por fonte, marcando as degradadas', () => {
+    const r = evaluateDrift([src('svrs', true, false), src('availability', true, true)]);
+    expect(r.lines).toHaveLength(2);
+    expect(r.lines[0]).toContain('[oficial] svrs');
+    expect(r.lines[1]).toContain('DEGRADADA');
+  });
+});


### PR DESCRIPTION
Fecha a MONITOR-6 (item 5 da Fase 8, marcada opcional). Detecta o drift de HTML do portal que as fixtures estáticas não capturam.

## O que faz

- `evaluateDrift(sources)` — função pura: há drift quando uma fonte **oficial** vem degradada (cobertura < piso). Terceiros degradados não contam.
- `drift-check` (novo script do collector) — faz 1 coleta ao vivo reusando `collectWithDiagnostics`, loga a cobertura por fonte e sai com código 1 em drift.
- `.github/workflows/drift-check.yml` — **non-blocking e separado** do pipeline: cron 1x/dia + dispatch, `continue-on-error`, anota `::warning::` e marca o run vermelho quando há drift, **sem afetar coleta nem deploy**.

## Verificação

- `evaluateDrift`: 4 testes (sem drift / oficial degradada / terceiro não conta / linhas legíveis).
- E2E: o `drift-check` ao vivo reportou a cobertura por fonte e saiu com código 1 ao detectar fonte oficial abaixo do piso.
- typecheck 12/12, lint 8/8, collector 22 testes.